### PR TITLE
Bumped the starting value of the EventData ID sequencer to 3 million.…

### DIFF
--- a/api-src/org/labkey/api/snd/SNDSequencer.java
+++ b/api-src/org/labkey/api/snd/SNDSequencer.java
@@ -27,7 +27,7 @@ public enum SNDSequencer
     PROJECTID ("org.labkey.snd.api.Project", 1000),
     PROJECTITEMID ("org.labkey.snd.api.ProjectItem", 30000),
     EVENTID ("org.labkey.snd.api.Event", 2000000),
-    EVENTDATAID ("org.labkey.snd.api.EventData", 2000000);
+    EVENTDATAID ("org.labkey.snd.api.EventData", 3000000);
 
     private String sequenceName;
     private int minId;


### PR DESCRIPTION
… The current value of 2 million is too low for the number of records in the legacy dataset.