### PR TITLE
appendNavTrail() to addNavTrail() migration

### DIFF
--- a/api-src/org/labkey/api/snd/PackageDomainKind.java
+++ b/api-src/org/labkey/api/snd/PackageDomainKind.java
@@ -42,6 +42,7 @@ public class PackageDomainKind extends ExtendedTableDomainKind
         return container.hasPermission("PackageDomainKind.canCreateDefinition", user, AdminPermission.class);
     }
 
+    @Override
     public String generateDomainURI(String schemaName, String tableName, Container c, User u)
     {
         return getDomainURI(schemaName, tableName, c, u);

--- a/src/org/labkey/snd/SNDController.java
+++ b/src/org/labkey/snd/SNDController.java
@@ -1222,14 +1222,13 @@ public class SNDController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             ActionURL url = new ActionURL(true);
             url.setPath("snd-admin.view");
             url.setContainer(getContainer());
             root.addChild("Admin Settings", url);
             root.addChild("Security");
-            return root;
         }
     }
 
@@ -1269,14 +1268,13 @@ public class SNDController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             ActionURL url = new ActionURL(true);
             url.setPath("snd-app.view");
             url.setContainer(getContainer());
             root.addChild("SND Home Page", url);
             root.addChild("SND Admin Settings and Controls");
-            return root;
         }
     }
 

--- a/src/org/labkey/snd/SNDServiceImpl.java
+++ b/src/org/labkey/snd/SNDServiceImpl.java
@@ -289,6 +289,7 @@ public class SNDServiceImpl implements SNDService
         return SNDManager.get().getLookupDisplayValue(u, c, schema, table, key);
     }
 
+    @Override
     public void saveProject(Container c, User u, Project project, boolean isRevision)
     {
         BatchValidationException errors = new BatchValidationException();
@@ -368,6 +369,7 @@ public class SNDServiceImpl implements SNDService
         return SNDSecurityManager.get().getQCState(c, u, qcStateId);
     }
 
+    @Override
     public JSONObject convertPropertyDescriptorToJson(Container c, User u, GWTPropertyDescriptor pd, boolean resolveLookupValues)
     {
         JSONObject json;
@@ -482,6 +484,7 @@ public class SNDServiceImpl implements SNDService
         SNDTriggerManager.get().unregisterEventTriggerFactory(module);
     }
 
+    @Override
     public List<Map<String, Object>> getMutableData(DataIteratorBuilder rows, DataIteratorContext context) throws IOException
     {
         DataIterator iterator = rows.getDataIterator(context);
@@ -499,6 +502,7 @@ public class SNDServiceImpl implements SNDService
         return mutableData;
     }
 
+    @Override
     public void fillInNarrativeCache(Container c, User u, Logger logger)
     {
         BatchValidationException errors = new BatchValidationException();
@@ -509,6 +513,7 @@ public class SNDServiceImpl implements SNDService
             throw new ApiUsageException(errors);
     }
 
+    @Override
     public void clearNarrativeCache(Container c, User u)
     {
         BatchValidationException errors = new BatchValidationException();
@@ -519,6 +524,7 @@ public class SNDServiceImpl implements SNDService
             throw new ApiUsageException(errors);
     }
 
+    @Override
     public void deleteNarrativeCacheRows(Container c, User u, List<Map<String, Object>> eventIds)
     {
         BatchValidationException errors = new BatchValidationException();
@@ -529,6 +535,7 @@ public class SNDServiceImpl implements SNDService
             throw new ApiUsageException(errors);
     }
 
+    @Override
     public void populateNarrativeCache(Container c, User u, List<Map<String, Object>> eventIds, Logger logger)
     {
         BatchValidationException errors = new BatchValidationException();
@@ -539,6 +546,7 @@ public class SNDServiceImpl implements SNDService
             throw new ApiUsageException(errors);
     }
 
+    @Override
     public Map<Integer, Category> getAllCategories(Container c, User u)
     {
         return SNDManager.get().getAllCategories(c, u);

--- a/test/src/org/labkey/test/components/snd/AttributeGridRow.java
+++ b/test/src/org/labkey/test/components/snd/AttributeGridRow.java
@@ -169,6 +169,7 @@ public class AttributeGridRow extends WebDriverComponent<AttributeGridRow.Elemen
         return elementCache().redactedTextInput.get();
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/components/snd/AttributesGrid.java
+++ b/test/src/org/labkey/test/components/snd/AttributesGrid.java
@@ -70,6 +70,7 @@ public class AttributesGrid extends WebDriverComponent<AttributesGrid.ElementCac
         return elementCache().getRow(key);
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/components/snd/CategoryEditRow.java
+++ b/test/src/org/labkey/test/components/snd/CategoryEditRow.java
@@ -84,6 +84,7 @@ public class CategoryEditRow extends WebDriverComponent<CategoryEditRow.ElementC
         elementCache().deleteLI.click();
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/components/snd/FilterSelect.java
+++ b/test/src/org/labkey/test/components/snd/FilterSelect.java
@@ -121,6 +121,7 @@ public class FilterSelect extends WebDriverComponent<FilterSelect.ElementCache>
         return Arrays.asList(selectionsContainer.getText().split(","));
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/components/snd/PackageViewerResult.java
+++ b/test/src/org/labkey/test/components/snd/PackageViewerResult.java
@@ -68,6 +68,7 @@ public class PackageViewerResult extends WebDriverComponent<PackageViewerResult.
         return new EditPackagePage(getDriver());
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/components/snd/ProjectViewerResult.java
+++ b/test/src/org/labkey/test/components/snd/ProjectViewerResult.java
@@ -78,6 +78,7 @@ public class ProjectViewerResult extends WebDriverComponent<ProjectViewerResult.
         return page;
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/components/snd/SuperPackageRow.java
+++ b/test/src/org/labkey/test/components/snd/SuperPackageRow.java
@@ -95,6 +95,7 @@ public class SuperPackageRow extends WebDriverComponent<SuperPackageRow.ElementC
        return this;
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/pages/snd/EditCategoriesPage.java
+++ b/test/src/org/labkey/test/pages/snd/EditCategoriesPage.java
@@ -91,6 +91,7 @@ public class EditCategoriesPage extends LabKeyPage<EditCategoriesPage.ElementCac
         return new PackageListPage(getDriver());
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/pages/snd/EditPackagePage.java
+++ b/test/src/org/labkey/test/pages/snd/EditPackagePage.java
@@ -191,6 +191,7 @@ public class EditPackagePage extends LabKeyPage<EditPackagePage.ElementCache>
         return new PackageListPage(getDriver());
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/pages/snd/EditProjectPage.java
+++ b/test/src/org/labkey/test/pages/snd/EditProjectPage.java
@@ -250,6 +250,7 @@ public class EditProjectPage extends LabKeyPage<EditProjectPage.ElementCache>
         return plp;
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/pages/snd/PackageListPage.java
+++ b/test/src/org/labkey/test/pages/snd/PackageListPage.java
@@ -87,6 +87,7 @@ public class PackageListPage extends LabKeyPage<PackageListPage.ElementCache>
                 .timeout(4000).findWhenNeeded(elementCache().container);
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/pages/snd/ProjectListPage.java
+++ b/test/src/org/labkey/test/pages/snd/ProjectListPage.java
@@ -114,6 +114,7 @@ public class ProjectListPage extends LabKeyPage<ProjectListPage.ElementCache>
                 .timeout(4000).findOrNull(elementCache().container);
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();


### PR DESCRIPTION
#### Rationale
Adjust actions to implement `void addNavTrail()` instead of `NavTree appendNavTrail()`. Also, bulk annotate with @Override. See platform PR for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1199