### PR TITLE
SND table changes and improvements to SND table CRUD performance for large imports

### DIFF
--- a/api-src/org/labkey/api/snd/Event.java
+++ b/api-src/org/labkey/api/snd/Event.java
@@ -56,6 +56,7 @@ public class Event
     private Map<EventNarrativeOption, String> narratives;
     private Map<GWTPropertyDescriptor, Object> _extraFields = new HashMap<>();
     private Integer _qcState;
+    private String _objectId;
 
     // This will store a count of the different severity of exceptions
     private Map<ValidationException.SEVERITY, Integer> _exceptionCount = new HashMap<>();
@@ -70,6 +71,7 @@ public class Event
     public static final String EVENT_DATA = "eventData";
     public static final String EVENT_PARENT_OBJECTID = "parentObjectId";
     public static final String EVENT_CONTAINER = "Container";
+    public static final String EVENT_OBJECTID = "ObjectId";
 
     public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'kk:mm:ss";  // ISO8601 w/24-hour time and 'T' character
 
@@ -82,7 +84,7 @@ public class Event
     public static final String SND_EXCEPTION_SEVERITY_JSON = "severity";
     public static final String SND_EXCEPTION_JSON = "exception";
 
-    public Event(@Nullable Integer eventId, String subjectId, @Nullable Date date, @NotNull String projectIdRev, @Nullable String note, @Nullable List<EventData> eventData, @NotNull Container c)
+    public Event(@Nullable Integer eventId, String subjectId, @Nullable Date date, @NotNull String projectIdRev, @Nullable String note, @Nullable List<EventData> eventData, @NotNull Container c, @Nullable String objectId)
     {
         _eventId = eventId != null ? eventId : SNDSequencer.EVENTID.ensureId(c, null);
         _subjectId = subjectId;
@@ -91,6 +93,7 @@ public class Event
         _note = note;
         _eventData = eventData;
         _noteId = SNDSequencer.EVENTID.ensureId(c, null);
+        _objectId = objectId;
     }
 
     public Event () {}
@@ -229,6 +232,16 @@ public class Event
         _qcState = SNDService.get().getQCStateId(c, u, qcState);
     }
 
+    public String getObjectId()
+    {
+        return _objectId;
+    }
+
+    public void setObjectId(String objectId)
+    {
+        _objectId = objectId;
+    }
+
     public ValidationException getException()
     {
         return _eventException;
@@ -302,6 +315,7 @@ public class Event
         eventValues.put(EVENT_PARENT_OBJECTID, getParentObjectId());
         eventValues.put(EVENT_QCSTATE, getQcState());
         eventValues.put(EVENT_CONTAINER, c.getId());
+        eventValues.put(EVENT_OBJECTID, getObjectId());
 
         Map<GWTPropertyDescriptor, Object> extras = getExtraFields();
         for (GWTPropertyDescriptor gpd : extras.keySet())
@@ -341,6 +355,10 @@ public class Event
         if (_qcState != null)
         {
             json.put(EVENT_QCSTATE, getQcState(c, u).getName());
+        }
+        if (_objectId != null)
+        {
+            json.put(EVENT_OBJECTID, getObjectId());
         }
 
         JSONArray eventDataJson = new JSONArray();

--- a/resources/schemas/dbscripts/sqlserver/snd-20.000-20.001.sql
+++ b/resources/schemas/dbscripts/sqlserver/snd-20.000-20.001.sql
@@ -1,0 +1,73 @@
+/*
+    Changes to improve snd.Events CRUD performance and add default QcState
+*/
+
+-- delete the trigger if it exists
+IF (OBJECT_ID(N'snd.ti_after_Events') IS NOT NULL)
+   BEGIN
+       DROP TRIGGER snd.ti_after_Events;
+   END;
+GO
+-- if QcState is null, set it to 'Completed'
+CREATE TRIGGER snd.ti_after_Events ON snd.Events FOR INSERT AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE snd.Events
+    SET QcState = (SELECT TOP(1) q.rowId FROM core.Qcstate AS q WHERE q.Label = 'Completed' ORDER BY q.rowId)
+    FROM inserted AS i
+             INNER JOIN snd.Events AS e ON i.EventId = e.EventId
+    WHERE i.QcState IS NULL
+END
+go
+
+-- move Events table cluster index to AnimalId, Date
+--
+-- need to drop foreign key constraints that reference the cluster index
+EXEC core.fn_dropifexists 'EventNotes', 'snd', 'CONSTRAINT', 'FK_SND_EVENTNOTES_EVENTID'
+EXEC core.fn_dropifexists 'EventData', 'snd', 'CONSTRAINT', 'FK_SND_EVENTDATA_EVENTID'
+EXEC core.fn_dropifexists 'EventsCache', 'snd', 'CONSTRAINT', 'FK_EventsCache_EventId'
+-- drop the snd.Events PK constraint (clustered index)
+EXEC core.fn_dropifexists 'Events', 'snd', 'CONSTRAINT', 'PK_SND_EVENTS'
+
+-- Add new snd.Events table PK constraint (non-clustered)
+ALTER TABLE snd.Events ADD  CONSTRAINT PK_SND_EVENTS PRIMARY KEY NONCLUSTERED
+    (
+     EventId ASC
+        )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+GO
+
+-- Create new clustered index on snd.Events
+EXEC core.fn_dropifexists 'Events', 'snd', 'INDEX', 'IDX_SND_EVENTS_SUBJECTID_DATE'
+CREATE CLUSTERED INDEX IDX_SND_EVENTS_SUBJECTID_DATE ON snd.Events
+    (
+     SubjectId ASC,
+     Date DESC
+        )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+GO
+
+
+-- restore constraints
+--
+-- EventNotes
+ALTER TABLE snd.EventNotes  WITH CHECK ADD  CONSTRAINT FK_SND_EVENTNOTES_EVENTID FOREIGN KEY(EventId)
+    REFERENCES snd.Events (EventId)
+GO
+
+ALTER TABLE snd.EventNotes CHECK CONSTRAINT FK_SND_EVENTNOTES_EVENTID
+GO
+
+-- EventData
+ALTER TABLE snd.EventData  WITH CHECK ADD  CONSTRAINT FK_SND_EVENTDATA_EVENTID FOREIGN KEY(EventId)
+    REFERENCES snd.Events (EventId)
+GO
+
+ALTER TABLE snd.EventData CHECK CONSTRAINT FK_SND_EVENTDATA_EVENTID
+GO
+
+-- EventsCache
+ALTER TABLE snd.EventsCache  WITH CHECK ADD  CONSTRAINT FK_EVENTSCACHE_EVENTID FOREIGN KEY(EventId)
+    REFERENCES snd.Events (EventId)
+GO
+
+ALTER TABLE snd.EventsCache CHECK CONSTRAINT FK_EventsCache_EventId
+GO

--- a/src/org/labkey/snd/SNDController.java
+++ b/src/org/labkey/snd/SNDController.java
@@ -47,6 +47,7 @@ import org.labkey.api.snd.SNDSequencer;
 import org.labkey.api.snd.SNDService;
 import org.labkey.api.snd.SuperPackage;
 import org.labkey.api.util.DateUtil;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
@@ -986,7 +987,7 @@ public class SNDController extends SpringActionController
             Boolean validateOnly = (Boolean) json.get("validateOnly");
             String qcStateString = json.getString("qcState");
             int qcState = SNDService.get().getQCStateId(getContainer(), getUser(), QCStateEnum.getByName(qcStateString));
-
+            String objectId = json.has("objectId") ? json.getString("objectId") : GUID.makeGUID();
             ApiSimpleResponse response = new ApiSimpleResponse();
 
             if (validateOnly == null)
@@ -1023,7 +1024,7 @@ public class SNDController extends SpringActionController
                     }
                 }
 
-                Event event = new Event(eventId, subjectId, date, projectIdrev, note, eventData, getContainer());
+                Event event = new Event(eventId, subjectId, date, projectIdrev, note, eventData, getContainer(), objectId);
                 event.setQcState(qcState);
 
                 // Get extra fields

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -2722,13 +2722,6 @@ public class SNDManager
             Map<String, Object> row;
             BatchValidationException errors = new BatchValidationException();
 
-            for (Integer cacheDatum : cacheData)
-            {
-                row = new HashMap<>();
-                row.put("EventId", cacheDatum);
-                rows.add(row);
-            }
-
             if (cacheData.size() > MAX_MERGE_ROWS)
             {
                 log.info("More than " + MAX_MERGE_ROWS + " rows. Truncating narrative cache");
@@ -2738,6 +2731,13 @@ public class SNDManager
             }
             else
             {
+                for (Integer cacheDatum : cacheData)
+                {
+                    row = new HashMap<>();
+                    row.put("EventId", cacheDatum);
+                    rows.add(row);
+                }
+
                 log.info("Deleting affected narrative cache rows.");
                 deleteNarrativeCacheRows(container, user, rows, errors);
                 //repopulate

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -19,6 +19,7 @@ package org.labkey.snd;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -129,6 +130,19 @@ public class SNDManager
     public static UserSchema getSndUserSchema(Container c, User u)
     {
         return new SNDUserSchema(SNDSchema.NAME, null, u, c, SNDSchema.getInstance().getSchema(), false);
+    }
+
+    public static int MAX_MERGE_ROWS = 100000;
+
+    public static Logger getLogger(Map<Enum, Object> configParameters, Class<?> clazz)
+    {
+        Logger log = null;
+        if (configParameters != null)
+            log = ((Logger) configParameters.get(QueryUpdateService.ConfigParameters.Logger));
+        if (log == null)
+            log = LogManager.getLogger(clazz);
+
+        return log;
     }
 
     public static String getPackageName(int id)
@@ -2691,6 +2705,55 @@ public class SNDManager
             }
         }
         return event;
+    }
+
+    // default to isUpdate = true
+    public int updateNarrativeCache(Container container, User user, Set<Integer>cacheData, Logger log)
+    {
+        return updateNarrativeCache(container, user, cacheData, log, true);
+    }
+    /* deletes and updates cached narratives */
+    public int updateNarrativeCache(Container container, User user, Set<Integer>cacheData, @NotNull Logger log, boolean isUpdate)
+    {
+        if (cacheData.size() > 0)
+        {
+            log.info("Deleting affected narrative cache rows.");
+            List<Map<String, Object>> rows = new ArrayList<>();
+            Map<String, Object> row;
+            BatchValidationException errors = new BatchValidationException();
+
+            for (Integer cacheDatum : cacheData)
+            {
+                row = new HashMap<>();
+                row.put("EventId", cacheDatum);
+                rows.add(row);
+            }
+
+            if (cacheData.size() > MAX_MERGE_ROWS)
+            {
+                log.info("More than " + MAX_MERGE_ROWS + " rows. Truncating narrative cache");
+                clearNarrativeCache(container, user, errors);
+                if (isUpdate)
+                    log.info("Not automatically populating narrative cache. Must refresh manually.");
+            }
+            else
+            {
+                log.info("Deleting affected narrative cache rows.");
+                deleteNarrativeCacheRows(container, user, rows, errors);
+                //repopulate
+                if (isUpdate)
+                {
+                    log.info("Repopulate affected rows in narrative cache.");
+                    populateNarrativeCache(container, user, rows, errors, log);
+                }
+            }
+
+            if (errors.hasErrors())
+            {
+                log.info("Error updating narrative cache.", errors.getMessage());
+            }
+        }
+        return cacheData.size();
     }
 
     /**

--- a/src/org/labkey/snd/SNDModule.java
+++ b/src/org/labkey/snd/SNDModule.java
@@ -65,7 +65,7 @@ public class SNDModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.000;
+        return 20.001;
     }
 
     @Override

--- a/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/src/org/labkey/snd/query/AttributeDataTable.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.snd.query;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -154,7 +153,6 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
     {
         private final SNDManager _sndManager = SNDManager.get();
         private final SNDService _sndService = SNDService.get();
-        private final Logger _logger = LogManager.getLogger(AttributeDataTable.class);
         private final DbSchema _expSchema = OntologyManager.getExpSchema();
 
         private Map<Integer, Object> packageMap = null;
@@ -178,7 +176,23 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
                 packageMap.put(pkgId, packageAttributes);
             }
         }
+        private int getRowCount(DataIteratorBuilder rows, @Nullable Map<Enum,Object> configParameters, BatchValidationException errors)
+        {
+            List<Map<String, Object>> data;
 
+            DataIteratorContext dataIteratorContext = getDataIteratorContext(errors, QueryUpdateService.InsertOption.MERGE, configParameters);
+
+            try
+            {
+                data = _sndService.getMutableData(rows, dataIteratorContext);
+            }
+            catch (IOException e)
+            {
+                return 0;
+            }
+
+            return data.size();
+        }
         private String getObjectURI(Integer eventDataId, Container c)
         {
             return _sndManager.generateLsid(c, String.valueOf(eventDataId));
@@ -209,35 +223,6 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
                 return (List<GWTPropertyDescriptor>) packageMap.get(pkgId);
 
             return null;
-        }
-
-        private void updateNarrativeCache(Container container, User user, Set<Integer>cacheData, Logger log)
-        {
-            if (cacheData.size() > 0)
-            {
-                log.info("Deleting affected narrative cache rows.");
-                List<Map<String, Object>> rows = new ArrayList<>();
-                Map<String, Object> row;
-
-                for (Integer cacheDatum : cacheData)
-                {
-                    row = new HashMap<>();
-                    row.put("EventId", cacheDatum);
-                    rows.add(row);
-                }
-
-                _sndService.deleteNarrativeCacheRows(container, user, rows);
-
-                if (cacheData.size() > 10000)
-                {
-                    log.info("Greater than 10,000 rows so not automatically populating narrative cache. Ensure to refresh manually.");
-                }
-                else
-                {
-                    log.info("Repopulate affected rows in narrative cache.");
-                    _sndService.populateNarrativeCache(container, user, rows, log);
-                }
-            }
         }
 
         private int insertObject(Container c, String uri, List<ObjectProperty> props, Integer pkgId, int inserted, Logger logger)
@@ -273,7 +258,6 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
             boolean found = false;
 
             Set<Integer> cacheEventIds = new HashSet<>();
-            int cacheCount = 0;
 
             for(Map<String, Object> row : data)
             {
@@ -288,13 +272,6 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
 
                 //add to list of cached narrative rows to delete
                 cacheEventIds.add((Integer) row.get("EventId"));
-                if (cacheEventIds.size() >= 100000)
-                {
-                    cacheCount += cacheEventIds.size();
-                    logger.info("Updating " + cacheEventIds.size() + " rows in event narrative cache.");
-                    updateNarrativeCache(container, user, cacheEventIds, logger);
-                    cacheEventIds = new HashSet<>();
-                }
 
                 String objectURI = getObjectURI((Integer) row.get("EventDataId"), container);
                 if (prevUri == null)
@@ -390,10 +367,7 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
             OntologyManager.clearPropertyCache();
             logger.info("End updating exp.ObjectProperty. Inserted/Updated " + inserted + " rows.");
 
-            cacheCount += cacheEventIds.size();
-            logger.info("Updating " + cacheEventIds.size() + " rows in event narrative cache.");
-            updateNarrativeCache(container, user, cacheEventIds, logger);
-            logger.info("Updated a total of " + cacheCount + " rows in event narrative cache.");
+            _sndManager.updateNarrativeCache(container, user, cacheEventIds, logger);
 
             return data;
         }
@@ -402,31 +376,32 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
         public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors,
                              @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
         {
+            Logger log = SNDManager.getLogger(configParameters, AttributeDataTable.class);
+
+            // Large merge triggers importRows path
+            if (getRowCount(rows, configParameters, errors) > SNDManager.MAX_MERGE_ROWS)
+            {
+                log.info("More than " + SNDManager.MAX_MERGE_ROWS + " rows. using importRows method.");
+                return importRows(user, container, rows, errors, configParameters, extraScriptContext);
+            }
+            log.info("Merging rows.");
             List<Map<String, Object>> data = getMutableData(rows, getDataIteratorContext(errors, InsertOption.MERGE, configParameters));
-            return updateObjectProperty(user, container, data, false, true, ((Logger)configParameters.get(QueryUpdateService.ConfigParameters.Logger))).size();
+            return updateObjectProperty(user, container, data, false, true, log).size();
         }
 
         @Override
         public int importRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors,
                               @Nullable Map<Enum,Object> configParameters, Map<String, Object> extraScriptContext)
         {
+            Logger log = SNDManager.getLogger(configParameters, AttributeDataTable.class);
             List<Map<String, Object>> data = getMutableData(rows, getDataIteratorContext(errors, InsertOption.IMPORT, configParameters));
-            return updateObjectProperty(user, container, data, true, false, ((Logger)configParameters.get(QueryUpdateService.ConfigParameters.Logger))).size();
+            return updateObjectProperty(user, container, data, true, false, log).size();
         }
 
         @Override
         public int truncateRows(User user, Container container, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext)
         {
-            Logger log = null;
-            if (configParameters != null)
-            {
-                log = ((Logger) configParameters.get(QueryUpdateService.ConfigParameters.Logger));
-            }
-
-            if (log == null)
-            {
-                log = _logger;
-            }
+            Logger log = SNDManager.getLogger(configParameters, AttributeDataTable.class);
 
             int numDeletedRows;
             String defaultLsidAuthority = AppProps.getInstance().getDefaultLsidAuthority();
@@ -461,16 +436,7 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
         public List<Map<String, Object>> deleteRows(User user, Container container, List<Map<String, Object>> oldRows,
                                                     @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext)
         {
-            Logger log = null;
-            if (configParameters != null)
-            {
-                log = ((Logger) configParameters.get(QueryUpdateService.ConfigParameters.Logger));
-            }
-
-            if (log == null)
-            {
-                log = _logger;
-            }
+            Logger log = SNDManager.getLogger(configParameters, AttributeDataTable.class);
 
             Set<Integer> cacheData = new HashSet<>();
             try (DbScope.Transaction tx = _expSchema.getScope().ensureTransaction())
@@ -500,7 +466,7 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
                 throw new IllegalStateException(e);
             }
 
-            updateNarrativeCache(container, user, cacheData, log);
+            _sndManager.updateNarrativeCache(container, user, cacheData, log, false);
 
             return oldRows;
         }

--- a/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/src/org/labkey/snd/query/AttributeDataTable.java
@@ -176,23 +176,7 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
                 packageMap.put(pkgId, packageAttributes);
             }
         }
-        private int getRowCount(DataIteratorBuilder rows, @Nullable Map<Enum,Object> configParameters, BatchValidationException errors)
-        {
-            List<Map<String, Object>> data;
 
-            DataIteratorContext dataIteratorContext = getDataIteratorContext(errors, QueryUpdateService.InsertOption.MERGE, configParameters);
-
-            try
-            {
-                data = _sndService.getMutableData(rows, dataIteratorContext);
-            }
-            catch (IOException e)
-            {
-                return 0;
-            }
-
-            return data.size();
-        }
         private String getObjectURI(Integer eventDataId, Container c)
         {
             return _sndManager.generateLsid(c, String.valueOf(eventDataId));
@@ -378,14 +362,15 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
         {
             Logger log = SNDManager.getLogger(configParameters, AttributeDataTable.class);
 
+            List<Map<String, Object>> data = getMutableData(rows, getDataIteratorContext(errors, InsertOption.MERGE, configParameters));
             // Large merge triggers importRows path
-            if (getRowCount(rows, configParameters, errors) > SNDManager.MAX_MERGE_ROWS)
+            if (data.size() > SNDManager.MAX_MERGE_ROWS)
             {
+                data.clear();
                 log.info("More than " + SNDManager.MAX_MERGE_ROWS + " rows. using importRows method.");
                 return importRows(user, container, rows, errors, configParameters, extraScriptContext);
             }
             log.info("Merging rows.");
-            List<Map<String, Object>> data = getMutableData(rows, getDataIteratorContext(errors, InsertOption.MERGE, configParameters));
             return updateObjectProperty(user, container, data, false, true, log).size();
         }
 

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -15,14 +15,29 @@
  */
 package org.labkey.snd.query;
 
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.snd.SNDService;
+import org.labkey.snd.SNDManager;
 import org.labkey.snd.SNDUserSchema;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 {
@@ -36,6 +51,61 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
     public EventNotesTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
     {
         super(schema, table, cf);
+    }
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        return new EventNotesTable.UpdateService(this);
+    }
+
+    protected class UpdateService extends SimpleQueryUpdateService
+    {
+        public UpdateService(SimpleUserSchema.SimpleTable ti)
+        {
+            super(ti, ti.getRealTable());
+        }
+
+        private final SNDService _sndService = SNDService.get();
+
+        private int getRowCount(DataIteratorBuilder rows, @Nullable Map<Enum,Object> configParameters, BatchValidationException errors)
+        {
+            List<Map<String, Object>> data;
+
+            DataIteratorContext dataIteratorContext = getDataIteratorContext(errors, QueryUpdateService.InsertOption.MERGE, configParameters);
+
+            try
+            {
+                data = _sndService.getMutableData(rows, dataIteratorContext);
+            }
+            catch (IOException e)
+            {
+                return 0;
+            }
+
+            return data.size();
+        }
+
+        @Override
+        public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors,
+                              @Nullable Map<Enum,Object> configParameters, Map<String, Object> extraScriptContext)
+        {
+            Logger log = SNDManager.getLogger(configParameters, EventNotesTable.class);
+            // Large merge triggers importRows path
+            int result = 0;
+            if (getRowCount(rows, configParameters, errors) > SNDManager.MAX_MERGE_ROWS)
+            {
+                log.info("More than " + SNDManager.MAX_MERGE_ROWS + " rows. using importRows method.");
+                result = super.importRows(user, container, rows, errors, configParameters, extraScriptContext);
+            }
+            else
+            {
+                log.info("Merging rows.");
+                result = super.mergeRows(user, container, rows, errors, configParameters, extraScriptContext);
+            }
+            return result;
+        }
+
     }
 
     @Override

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -27,6 +27,7 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -71,19 +72,21 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
         private int getRowCount(DataIteratorBuilder rows, @Nullable Map<Enum,Object> configParameters, BatchValidationException errors)
         {
             List<Map<String, Object>> data;
+            int rowCount = 0;
 
             DataIteratorContext dataIteratorContext = getDataIteratorContext(errors, QueryUpdateService.InsertOption.MERGE, configParameters);
 
             try
             {
                 data = _sndService.getMutableData(rows, dataIteratorContext);
+                rowCount = data.size();
             }
             catch (IOException e)
             {
-                return 0;
+                errors.addRowError(new ValidationException(e.getMessage()));
             }
 
-            return data.size();
+            return rowCount;
         }
 
         @Override

--- a/src/org/labkey/snd/query/EventsTable.java
+++ b/src/org/labkey/snd/query/EventsTable.java
@@ -29,6 +29,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema.SimpleTable;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.snd.Event;
 import org.labkey.api.snd.SNDService;
@@ -92,6 +93,7 @@ public class EventsTable extends SimpleTable<SNDUserSchema>
             }
             catch (IOException e)
             {
+                errors.addRowError(new ValidationException(e.getMessage()));
                 return eventIds;
             }
 


### PR DESCRIPTION
#### Rationale
SND table changes and improvements to SND table CRUD performance for large imports

#### Related Pull Requests

#### Changes
1. changes to how objectIds and QcStates are handled in the Events table
1. added a default value for QcState in the snd.Events table via a Sql Server trigger
2. added SNDManager.MAX_MERGE_ROWS = 100,000 as a trigger point for switching from merging to importing large data sets
3. refactored getLogger() method into SNDManager
4. refactored AttributeDataTable, EventNotes, EventDateTable, and EventsTable to use MAX_MERGE_ROWS to determine import type
5. when merging snd.Events, truncate narrative cache if number of rows > 10,000 - to prevent unecessary single row deletes
6. moved updateNarrativeCache method to SNDManager.java
7. incremented module version
