### PR TITLE
PlainTextNarrative.getDisplayValue override

### DIFF
--- a/src/org/labkey/snd/table/PlainTextNarrativeDisplayColumn.java
+++ b/src/org/labkey/snd/table/PlainTextNarrativeDisplayColumn.java
@@ -36,6 +36,13 @@ public class PlainTextNarrativeDisplayColumn extends DataColumn
         return HtmlString.of(removeHtmlTagsFromNarrative(htmlNarrative));
     }
 
+    @Override
+    public Object getDisplayValue(RenderContext ctx)
+    {
+        String htmlNarrative = (String)ctx.get(getColumnInfo().getFieldKey());
+        return removeHtmlTagsFromNarrative(htmlNarrative);
+    }
+
    public static String removeHtmlTagsFromNarrative(String htmlNarrative)
    {
        String textNarrative;


### PR DESCRIPTION
#### Rationale
SND.EventsCache table is converting PlainTextNarrativeDisplayColumn to plain text in getFormattedHtml() for viewing in LK grid, but not being converted in getDisplayValue().  This PR adds that override.

#### Changes
- Add PlainTextNarrativeDisplayColumn.getDisplayValue() override to strip out HTML tags.
