### PR TITLE
Generate webpack files into gen directory for better build caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ app.js.map
 .labkey
 import
 resources/web/snd/app/style.js
+.gradle

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       }
     },
     "clean": {
-      "command": "rimraf resources/web/snd/app/"
+      "command": "rimraf resources/web/snd/gen && rimraf resources/web/snd/app"
     }
   },
   "repository": {

--- a/resources/views/app.view.xml
+++ b/resources/views/app.view.xml
@@ -3,7 +3,7 @@
         <permission name="login"/>
     </permissions>
     <dependencies>
-        <dependency path="snd/app/app.css"/>
-        <dependency path="snd/app/app.js"/>
+        <dependency path="snd/gen/app/app.css"/>
+        <dependency path="snd/gen/app/app.js"/>
     </dependencies>
 </view>

--- a/resources/views/appDev.view.xml
+++ b/resources/views/appDev.view.xml
@@ -3,6 +3,6 @@
         <permission name="login"/>
     </permissions>
     <dependencies>
-        <dependency path="snd/app/app.css"/>
+        <dependency path="snd/gen/app/app.css"/>
     </dependencies>
 </view>

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -22,7 +22,7 @@ module.exports = {
     },
 
     output: {
-        path: path.resolve(__dirname, '../resources/web/snd/app/'),
+        path: path.resolve(__dirname, '../resources/web/snd/gen/app/'),
         publicPath: './', // allows context path to resolve in both js/css
         filename: "[name].js"
     },


### PR DESCRIPTION
#### Rationale
For optimal use of the Gradle build cache, we need to generate webpack output into a dedicated directory.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/98

#### Changes
* Update webpack build into `gen` directory
* Adjust npm `clean` task to clean out `gen` directory
