### PR TITLE
Change DATE_TIME_FORMAT in AttributeData and Event to use 0-23 for hours format

### DIFF
--- a/api-src/org/labkey/api/snd/AttributeData.java
+++ b/api-src/org/labkey/api/snd/AttributeData.java
@@ -41,7 +41,7 @@ public class AttributeData
 
     public static final String ATTRIBUTE_DATA_CSS_CLASS = "snd-attribute-data";
 
-    public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'kk:mm:ss";  // ISO8601 w/24-hour time and 'T' character
+    public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";  // ISO8601 w/24-hour time and 'T' character
     public static final String DATE_FORMAT = "yyyy-MM-dd";  // ISO8601
 
     public AttributeData(int propertyId, @Nullable GWTPropertyDescriptor propertyDescriptor, @Nullable String value)

--- a/api-src/org/labkey/api/snd/Event.java
+++ b/api-src/org/labkey/api/snd/Event.java
@@ -73,7 +73,7 @@ public class Event
     public static final String EVENT_CONTAINER = "Container";
     public static final String EVENT_OBJECTID = "ObjectId";
 
-    public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'kk:mm:ss";  // ISO8601 w/24-hour time and 'T' character
+    public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";  // ISO8601 w/24-hour time and 'T' character
 
     public static final String SND_EVENT_NAMESPACE = "SND.EventData";
 


### PR DESCRIPTION
#### Rationale
Date/time format request change

#### Related Pull Requests
n/a
#### Changes
Change DATE_TIME_FORMAT in AttributeData and Event to use 0-23 for hours format
