### PR TITLE
fb_procNotesFix

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -2531,13 +2531,15 @@ public class SNDManager
                                 BatchValidationException errors = new BatchValidationException();
 
                                 QueryUpdateService eventNotesQus = null;
-                                // make sure there is an event note to insert - event notes are optional
-                                if (event.getEventNotesRow(c).get("note") != null) {
+
+                                // make sure there is an event note to insert - event notes are optional - trim spaces
+                                if (event.getEventNotesRow(c).containsKey("note") && event.getEventNotesRow(c).get("note") != null && event.getEventNotesRow(c).get("note").toString().trim().length() > 0)
                                     eventNotesQus = getNewQueryUpdateService(schema, SNDSchema.EVENTNOTES_TABLE_NAME);
-                                }
+
                                 try (DbScope.Transaction tx = eventTable.getSchema().getScope().ensureTransaction())
                                 {
                                     eventQus.insertRows(u, c, Collections.singletonList(event.getEventRow(c)), errors, null, null);
+
                                     // insert event note if it exists
                                     if (eventNotesQus != null)
                                     {
@@ -2685,7 +2687,13 @@ public class SNDManager
                                 UserSchema schema = getSndUserSchema(c, u);
                                 TableInfo eventTable = getTableInfo(schema, SNDSchema.EVENTS_TABLE_NAME);
                                 QueryUpdateService eventQus = getQueryUpdateService(eventTable);
-                                QueryUpdateService eventNotesQus = getNewQueryUpdateService(schema, SNDSchema.EVENTNOTES_TABLE_NAME);
+                                QueryUpdateService eventNotesQus = null;
+
+                                // make sure there is an event note to insert - event notes are optional - trim spaces
+                                if (event.getEventNotesRow(c).containsKey("note") && event.getEventNotesRow(c).get("note") != null && event.getEventNotesRow(c).get("note").toString().trim().length() > 0)
+                                    eventNotesQus = getNewQueryUpdateService(schema, SNDSchema.EVENTNOTES_TABLE_NAME);
+
+                                //QueryUpdateService eventNotesQus = getNewQueryUpdateService(schema, SNDSchema.EVENTNOTES_TABLE_NAME);
                                 QueryUpdateService eventsCacheQus = getNewQueryUpdateService(schema, SNDSchema.EVENTSCACHE_TABLE_NAME);
 
                                 String htmlEventNarrative = generateEventNarrative(c, u, event, topLevelEventDataSuperPkgs, true, false);
@@ -2697,7 +2705,13 @@ public class SNDManager
                                 {
                                     eventQus.updateRows(u, c, Collections.singletonList(event.getEventRow(c)), null, null, null);
                                     deleteEventNotes(c, u, event.getEventId());
-                                    eventNotesQus.insertRows(u, c, Collections.singletonList(event.getEventNotesRow(c)), errors, null, null);
+                                    // insert event note if it exists
+                                    if (eventNotesQus != null)
+                                    {
+                                        eventNotesQus.insertRows(u, c, Collections.singletonList(event.getEventNotesRow(c)), errors, null, null);
+                                    }
+
+
                                     deleteEventDatas(c, u, event.getEventId());
                                     insertEventDatas(c, u, event, errors);
                                     eventsCacheQus.updateRows(u, c, Collections.singletonList(eventsCacheRow), null, null, null);

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -2693,7 +2693,6 @@ public class SNDManager
                                 if (event.getEventNotesRow(c).containsKey("note") && event.getEventNotesRow(c).get("note") != null && event.getEventNotesRow(c).get("note").toString().trim().length() > 0)
                                     eventNotesQus = getNewQueryUpdateService(schema, SNDSchema.EVENTNOTES_TABLE_NAME);
 
-                                //QueryUpdateService eventNotesQus = getNewQueryUpdateService(schema, SNDSchema.EVENTNOTES_TABLE_NAME);
                                 QueryUpdateService eventsCacheQus = getNewQueryUpdateService(schema, SNDSchema.EVENTSCACHE_TABLE_NAME);
 
                                 String htmlEventNarrative = generateEventNarrative(c, u, event, topLevelEventDataSuperPkgs, true, false);


### PR DESCRIPTION
#### Rationale
1. Don't try to insert into or update the EventNotes table if the event note is missing
2. Don't try to save an event note that is only spaces

#### Related Pull Requests
None

#### Changes
See rationale