### PR TITLE
SND table auditing changes

### DIFF
--- a/resources/schemas/snd.xml
+++ b/resources/schemas/snd.xml
@@ -116,7 +116,6 @@
         </columns>
     </table>
     <table tableName="PkgCategoryJunction" tableDbType="TABLE">
-        <auditLogging>DETAILED</auditLogging>
         <insertUrl>/snd/app.view?#/categories</insertUrl>
         <updateUrl></updateUrl> <!--TODO: /snd/app.view?#/categories-->
         <importUrl></importUrl>


### PR DESCRIPTION
#### Rationale
Recent dataintegration changes do not support detailed auditing on tables with composite PKs merging on an AK

#### Related Pull Requests
none

#### Changes
removed detailed auditing from snd.PkgCategoryJunction
