### PR TITLE
Add loadRows to SND table QUSes

### DIFF
--- a/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/src/org/labkey/snd/query/AttributeDataTable.java
@@ -39,7 +39,6 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QueryUpdateService;
-import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
@@ -149,7 +148,7 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
         return new AttributeDataTable.UpdateService(simpleTable);
     }
 
-    protected class UpdateService extends SimpleQueryUpdateService
+    protected class UpdateService extends SNDQueryUpdateService
     {
         private final SNDManager _sndManager = SNDManager.get();
         private final SNDService _sndService = SNDService.get();
@@ -354,19 +353,6 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
             _sndManager.updateNarrativeCache(container, user, cacheEventIds, logger);
 
             return data;
-        }
-
-        @Override
-        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
-        {
-            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
-            {
-                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
-            else
-            {
-                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
         }
 
         @Override

--- a/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/src/org/labkey/snd/query/AttributeDataTable.java
@@ -357,6 +357,19 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
         }
 
         @Override
+        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
+        {
+            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
+            {
+                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
+            else
+            {
+                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
+        }
+
+        @Override
         public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors,
                              @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
         {

--- a/src/org/labkey/snd/query/EventDataTable.java
+++ b/src/org/labkey/snd/query/EventDataTable.java
@@ -34,7 +34,6 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
-import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -78,7 +77,7 @@ public class EventDataTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
         return new EventDataTable.UpdateService(this);
     }
 
-    protected class UpdateService extends SimpleQueryUpdateService
+    protected class UpdateService extends SNDQueryUpdateService
     {
         private final SNDManager _sndManager = SNDManager.get();
         private final SNDService _sndService = SNDService.get();
@@ -92,19 +91,6 @@ public class EventDataTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
         private String getObjectURI(Integer eventDataId, Container c)
         {
             return _sndManager.generateLsid(c, String.valueOf(eventDataId));
-        }
-
-        @Override
-        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
-        {
-            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
-            {
-                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
-            else
-            {
-                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
         }
 
         @Override

--- a/src/org/labkey/snd/query/EventDataTable.java
+++ b/src/org/labkey/snd/query/EventDataTable.java
@@ -95,6 +95,19 @@ public class EventDataTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
         }
 
         @Override
+        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
+        {
+            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
+            {
+                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
+            else
+            {
+                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
+        }
+
+        @Override
         public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors,
                              @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
         {

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -90,6 +90,19 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
         }
 
         @Override
+        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
+        {
+            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
+            {
+                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
+            else
+            {
+                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
+        }
+
+        @Override
         public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors,
                               @Nullable Map<Enum,Object> configParameters, Map<String, Object> extraScriptContext)
         {

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -25,7 +25,6 @@ import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryUpdateService;
-import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
@@ -60,7 +59,7 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
         return new EventNotesTable.UpdateService(this);
     }
 
-    protected class UpdateService extends SimpleQueryUpdateService
+    protected class UpdateService extends SNDQueryUpdateService
     {
         public UpdateService(SimpleUserSchema.SimpleTable ti)
         {
@@ -87,19 +86,6 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
             }
 
             return rowCount;
-        }
-
-        @Override
-        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
-        {
-            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
-            {
-                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
-            else
-            {
-                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
         }
 
         @Override

--- a/src/org/labkey/snd/query/EventsTable.java
+++ b/src/org/labkey/snd/query/EventsTable.java
@@ -114,6 +114,19 @@ public class EventsTable extends SimpleTable<SNDUserSchema>
         }
 
         @Override
+        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
+        {
+            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
+            {
+                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
+            else
+            {
+                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
+        }
+
+        @Override
         public int importRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors,
                               @Nullable Map<Enum,Object> configParameters, Map<String, Object> extraScriptContext)
         {

--- a/src/org/labkey/snd/query/EventsTable.java
+++ b/src/org/labkey/snd/query/EventsTable.java
@@ -27,7 +27,6 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
-import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema.SimpleTable;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
@@ -72,7 +71,7 @@ public class EventsTable extends SimpleTable<SNDUserSchema>
         return new EventsTable.UpdateService(this);
     }
 
-    protected class UpdateService extends SimpleQueryUpdateService
+    protected class UpdateService extends SNDQueryUpdateService
     {
         public UpdateService(SimpleTable ti)
         {
@@ -111,19 +110,6 @@ public class EventsTable extends SimpleTable<SNDUserSchema>
         {
             _sndService.clearNarrativeCache(container, user);
             return super.truncateRows(user, container, configParameters, extraScriptContext);
-        }
-
-        @Override
-        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
-        {
-            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
-            {
-                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
-            else
-            {
-                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
         }
 
         @Override

--- a/src/org/labkey/snd/query/LookupsTable.java
+++ b/src/org/labkey/snd/query/LookupsTable.java
@@ -20,6 +20,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
@@ -59,6 +60,19 @@ public class LookupsTable extends SimpleTable<SNDUserSchema>
         public UpdateService(SimpleTable ti)
         {
             super(ti, ti.getRealTable());
+        }
+
+        @Override
+        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
+        {
+            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
+            {
+                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
+            else
+            {
+                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+            }
         }
 
         @Override

--- a/src/org/labkey/snd/query/LookupsTable.java
+++ b/src/org/labkey/snd/query/LookupsTable.java
@@ -20,12 +20,10 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
-import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
-import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema.SimpleTable;
 import org.labkey.api.security.User;
 import org.labkey.snd.SNDManager;
@@ -55,24 +53,11 @@ public class LookupsTable extends SimpleTable<SNDUserSchema>
         return new LookupsTable.UpdateService(this);
     }
 
-    protected class UpdateService extends SimpleQueryUpdateService
+    protected class UpdateService extends SNDQueryUpdateService
     {
         public UpdateService(SimpleTable ti)
         {
             super(ti, ti.getRealTable());
-        }
-
-        @Override
-        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
-        {
-            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
-            {
-                return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
-            else
-            {
-                return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
-            }
         }
 
         @Override

--- a/src/org/labkey/snd/query/SNDQueryUpdateService.java
+++ b/src/org/labkey/snd/query/SNDQueryUpdateService.java
@@ -1,0 +1,37 @@
+package org.labkey.snd.query;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.SimpleQueryUpdateService;
+import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.security.User;
+
+import java.util.Map;
+
+public class SNDQueryUpdateService extends SimpleQueryUpdateService
+{
+    public SNDQueryUpdateService(SimpleUserSchema.SimpleTable queryTable, TableInfo dbTable)
+    {
+        super(queryTable, dbTable);
+    }
+
+    // Most of the SND tables have custom operations associated with mergeRows or importRows. loadRows also needs
+    // to execute that custom logic.  For example when rows are loaded via ETL merge, loadRows is called
+    // and the custom table logic for merging should be executed.
+    @Override
+    public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
+    {
+        if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE || context.getInsertOption() == QueryUpdateService.InsertOption.REPLACE)
+        {
+            return mergeRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+        }
+        else
+        {
+            return importRows(user, container, rows, context.getErrors(), context.getConfigParameters(), extraScriptContext);
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
Related PR in dataintegration calls loadRows instead of mergeRows in TransformTask.appendToTargetQuery.  Add loadRows to SND tables to call mergeRows or importRows depending on insert option.

#### Related Pull Requests
* https://github.com/LabKey/dataintegration/pull/99

#### Changes
* Add loadRows to SND table QUSes
