### PR TITLE
Don't try to save attribute data if property value is null

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -1732,12 +1732,13 @@ public class SNDManager
         Object propValue;
         for (GWTPropertyDescriptor gwtPropertyDescriptor : superPackage.getPkg().getAttributes())
         {
-            attribute = new AttributeData();
-            attribute.setPropertyName(gwtPropertyDescriptor.getName());
-            attribute.setPropertyDescriptor(gwtPropertyDescriptor);
-            attribute.setPropertyId(gwtPropertyDescriptor.getPropertyId());
-            if (properties != null && properties.get(gwtPropertyDescriptor.getPropertyURI()) != null)
+            if (properties != null && properties.get(gwtPropertyDescriptor.getPropertyURI()) != null && properties.get(gwtPropertyDescriptor.getPropertyURI()).value() != null)
             {
+                attribute = new AttributeData();
+                attribute.setPropertyName(gwtPropertyDescriptor.getName());
+                attribute.setPropertyDescriptor(gwtPropertyDescriptor);
+                attribute.setPropertyId(gwtPropertyDescriptor.getPropertyId());
+
                 //TODO: Add redacted here
                 propValue = properties.get(gwtPropertyDescriptor.getPropertyURI()).value();
 
@@ -1752,9 +1753,9 @@ public class SNDManager
                 }
 
                 attribute.setValue(propValue.toString());
-            }
 
-            attributeDatas.add(attribute);
+                attributeDatas.add(attribute);
+            }
         }
 
         eventData.setAttributes(attributeDatas);

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -1732,30 +1732,31 @@ public class SNDManager
         Object propValue;
         for (GWTPropertyDescriptor gwtPropertyDescriptor : superPackage.getPkg().getAttributes())
         {
-            if (properties != null && properties.get(gwtPropertyDescriptor.getPropertyURI()) != null && properties.get(gwtPropertyDescriptor.getPropertyURI()).value() != null)
+            attribute = new AttributeData();
+            attribute.setPropertyName(gwtPropertyDescriptor.getName());
+            attribute.setPropertyDescriptor(gwtPropertyDescriptor);
+            attribute.setPropertyId(gwtPropertyDescriptor.getPropertyId());
+            if (properties != null && properties.get(gwtPropertyDescriptor.getPropertyURI()) != null)
             {
-                attribute = new AttributeData();
-                attribute.setPropertyName(gwtPropertyDescriptor.getName());
-                attribute.setPropertyDescriptor(gwtPropertyDescriptor);
-                attribute.setPropertyId(gwtPropertyDescriptor.getPropertyId());
-
                 //TODO: Add redacted here
                 propValue = properties.get(gwtPropertyDescriptor.getPropertyURI()).value();
-
-                // Convert dates to ISO8601 format
-                if (PropertyType.getFromURI(null, gwtPropertyDescriptor.getRangeURI()).equals(PropertyType.DATE))
+                if (propValue != null)
                 {
-                    propValue = DateUtil.formatDateTime((Date) propValue, AttributeData.DATE_FORMAT);
-                }
-                else if (PropertyType.getFromURI(null, gwtPropertyDescriptor.getRangeURI()).equals(PropertyType.DATE_TIME))
-                {
-                    propValue = DateUtil.formatDateTime((Date) propValue, AttributeData.DATE_TIME_FORMAT);
-                }
+                    // Convert dates to ISO8601 format
+                    if (PropertyType.getFromURI(null, gwtPropertyDescriptor.getRangeURI()).equals(PropertyType.DATE))
+                    {
+                        propValue = DateUtil.formatDateTime((Date) propValue, AttributeData.DATE_FORMAT);
+                    }
+                    else if (PropertyType.getFromURI(null, gwtPropertyDescriptor.getRangeURI()).equals(PropertyType.DATE_TIME))
+                    {
+                        propValue = DateUtil.formatDateTime((Date) propValue, AttributeData.DATE_TIME_FORMAT);
+                    }
 
-                attribute.setValue(propValue.toString());
-
-                attributeDatas.add(attribute);
+                    attribute.setValue(propValue.toString());
+                }
             }
+
+            attributeDatas.add(attribute);
         }
 
         eventData.setAttributes(attributeDatas);


### PR DESCRIPTION
#### Rationale
Fix NPE that is getting thrown when property value for attribute data is null

#### Related Pull Requests

#### Changes
Add value null check to property validation when getting event data to avoid NPE when processing value.
