### PR TITLE
Update PackageAttribute table query

### DIFF
--- a/src/org/labkey/snd/query/PackageAttributeTable.java
+++ b/src/org/labkey/snd/query/PackageAttributeTable.java
@@ -238,7 +238,7 @@ public class PackageAttributeTable extends FilteredTable<SNDUserSchema>
         sql.append(" INNER JOIN ");
         sql.append(OntologyManager.getTinfoPropertyDescriptor(), "pd");
         sql.append(" ON pd.PropertyId = pdom.PropertyId ");
-        sql.append(" INNER JOIN ");
+        sql.append(" LEFT JOIN ");
         sql.append(" exp.PropertyValidator pv");
         sql.append(" ON pd.PropertyId = pv.PropertyId ");
         sql.append(") ");


### PR DESCRIPTION
#### Rationale
As discussed, the join on property validators should be a left join instead of inner to show all attributes regardless if they have validators.

#### Changes
* Updated query
