### PR TITLE
Update the attributes from the pipeline job unconditionally

### DIFF
--- a/api-src/org/labkey/api/snd/SNDService.java
+++ b/api-src/org/labkey/api/snd/SNDService.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.api.snd;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
@@ -48,6 +47,7 @@ public interface SNDService
 
     void savePackage(Container c, User u, Package pkg);
     void savePackage(Container c, User u, Package pkg, SuperPackage superPkg, boolean cloneFlag);
+    void savePackage(Container c, User u, Package pkg, SuperPackage superPkg, boolean cloneFlag, boolean isPipelineJob);
     void saveSuperPackages(Container c, User u, List<SuperPackage> superPkgs);
     List<Package> getPackages(Container c, User u, List<Integer> pkgIds, boolean includeExtraFields, boolean includeLookups, boolean includeFullSubpackages);
     void registerAttributeLookup(Container c, User u, String schema, @Nullable String table);

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -287,7 +287,11 @@ public class SNDManager
     /**
      * Called from SNDService.savePackage when saving updates to an already existing package.
      */
-    public void updatePackage(User u, Container c, @NotNull Package pkg, @Nullable SuperPackage superPkg, BatchValidationException errors)
+    public void updatePackage(User u, Container c, @NotNull Package pkg, @Nullable SuperPackage superPkg, BatchValidationException errors) {
+       updatePackage(u, c, pkg, superPkg, errors, false);
+    }
+
+    public void updatePackage(User u, Container c, @NotNull Package pkg, @Nullable SuperPackage superPkg, BatchValidationException errors, boolean isPipelineJob)
     {
         UserSchema schema = getSndUserSchema(c, u);
 
@@ -317,7 +321,7 @@ public class SNDManager
         if (!errors.hasErrors())
         {
             // If package is in use (either assigned to an event or project) then do not update the domain
-            if (!((PackagesTable) pkgsTable).isPackageInUse(pkg.getPkgId()))
+            if (!((PackagesTable) pkgsTable).isPackageInUse(pkg.getPkgId()) || isPipelineJob )
             {
                 String domainURI = PackageDomainKind.getDomainURI(PackageDomainKind.getPackageSchemaName(), getPackageName(pkg.getPkgId()), c, u);
 

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -321,6 +321,7 @@ public class SNDManager
         if (!errors.hasErrors())
         {
             // If package is in use (either assigned to an event or project) then do not update the domain
+            // If pipeline import job is running then always update
             if (!((PackagesTable) pkgsTable).isPackageInUse(pkg.getPkgId()) || isPipelineJob )
             {
                 String domainURI = PackageDomainKind.getDomainURI(PackageDomainKind.getPackageSchemaName(), getPackageName(pkg.getPkgId()), c, u);

--- a/src/org/labkey/snd/SNDServiceImpl.java
+++ b/src/org/labkey/snd/SNDServiceImpl.java
@@ -207,6 +207,7 @@ public class SNDServiceImpl implements SNDService
         savePackage(c, u, pkg, superPkg, cloneFlag, false);
     }
 
+    @Override
     public void savePackage(Container c, User u, Package pkg, SuperPackage superPkg, boolean cloneFlag, boolean isPipelineJob)
     {
         BatchValidationException errors = new BatchValidationException();

--- a/src/org/labkey/snd/SNDServiceImpl.java
+++ b/src/org/labkey/snd/SNDServiceImpl.java
@@ -199,11 +199,15 @@ public class SNDServiceImpl implements SNDService
     @Override
     public void savePackage(Container c, User u, Package pkg)
     {
-        savePackage(c, u, pkg, null, false);
+        savePackage(c, u, pkg, null, false, false);
     }
 
     @Override
-    public void savePackage(Container c, User u, Package pkg, SuperPackage superPkg, boolean cloneFlag)
+    public void savePackage(Container c, User u, Package pkg, SuperPackage superPkg, boolean cloneFlag) {
+        savePackage(c, u, pkg, superPkg, cloneFlag, false);
+    }
+
+    public void savePackage(Container c, User u, Package pkg, SuperPackage superPkg, boolean cloneFlag, boolean isPipelineJob)
     {
         BatchValidationException errors = new BatchValidationException();
         Domain domain = null;
@@ -218,7 +222,7 @@ public class SNDServiceImpl implements SNDService
         {
             if ((null != domain) && !cloneFlag)  // clone case is basically creation
             {
-                SNDManager.get().updatePackage(u, c, pkg, superPkg, errors);
+                SNDManager.get().updatePackage(u, c, pkg, superPkg, errors, isPipelineJob);
             }
             else
             {

--- a/src/org/labkey/snd/pipeline/SNDDataHandler.java
+++ b/src/org/labkey/snd/pipeline/SNDDataHandler.java
@@ -140,7 +140,7 @@ public class SNDDataHandler extends AbstractExperimentDataHandler
         for (PackageType packageType : packageArray)
         {
             Package pkg = parsePackage(packageType, info); //convert auto-generated objects/tokens to SND's Package objects
-            sndService.savePackage(info.getContainer(), info.getUser(), pkg); //save to db
+            sndService.savePackage(info.getContainer(), info.getUser(), pkg, null,false, true); //save to db
             log.info("Saving package: " + packageType.getId() + "-" + packageType.getDescription());
         }
     }


### PR DESCRIPTION
#### Rationale
Truncating and reloading lookup table ETLs causes the default lookup values to get out of sync with the lookup options. This patch allows the pipeline import job to update the defaultValues in existing packages.

#### Related Pull Requests
none

#### Changes
Refactored SndManager.updatePackage() to update the attributes from the pipeline job unconditionally
