### PR TITLE
Add triggers to prevent truncate on lookup tables

### DIFF
--- a/resources/queries/snd/LookupSets.js
+++ b/resources/queries/snd/LookupSets.js
@@ -1,0 +1,8 @@
+
+
+function init(event){
+
+    if (event === 'truncate') {
+        throw "Not allowed to truncate snd.LookupSets. Truncating this table can orphan lookup values in snd data.";
+    }
+}

--- a/resources/queries/snd/Lookups.js
+++ b/resources/queries/snd/Lookups.js
@@ -1,0 +1,48 @@
+
+
+var console = require("console");
+var LABKEY = require("labkey");
+
+function init(event){
+
+    if (event === 'truncate') {
+        throw "Not allowed to truncate snd.Lookups. Truncating this table can orphan lookup values in snd data.";
+    }
+}
+
+function onUpsert(row, errors) {
+
+    if (row.LookupSetId === undefined || row.LookupSetId == 'undefined') {
+        LABKEY.Query.selectRows({
+            schemaName: 'snd',
+            queryName: 'LookupSets',
+            columns: 'LookupSetId',
+            scope: this,
+            filterArray: [
+                LABKEY.Filter.create('SetName', row.SetName, LABKEY.Filter.Types.EQUAL),
+
+            ],
+            success: function (data) {
+                if (data.rows && data.rows.length) {
+                    row.LookupSetId = data.rows[0].LookupSetId;
+
+                    //  console.log('caching ' + cacheKey + ': ' + row.GroupId);
+                }
+            },
+            failure: function (error) {
+                console.log('Select rows error');
+                console.log(error);
+            }
+        });
+    }
+}
+
+function beforeInsert(row, errors) {
+    onUpsert(row, errors);
+}
+
+function beforeUpdate(row, errors) {
+    onUpsert(row, errors);
+}
+
+

--- a/test/src/org/labkey/test/tests/snd/SNDTest.java
+++ b/test/src/org/labkey/test/tests/snd/SNDTest.java
@@ -72,6 +72,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -953,13 +954,17 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         List<Map<String, Object>> lookupSetRows = Arrays.asList(
                 new HashMap<String, Object>(Maps.of("SetName", "SurgeryType",
                         "Label", "Surgery Type",
-                        "Description", "These are surgery types")),
-                new HashMap<String, Object>(Maps.of("SetName", "BloodDrawType")),
+                        "Description", "These are surgery types",
+                        "ObjectId", UUID.randomUUID().toString())),
+                new HashMap<String, Object>(Maps.of("SetName", "BloodDrawType",
+                        "ObjectId", UUID.randomUUID().toString())),
                 new HashMap<String, Object>(Maps.of("SetName", "GenderType",
-                        "Label", "Gender")),
+                        "Label", "Gender",
+                        "ObjectId", UUID.randomUUID().toString())),
                 new HashMap<String, Object>(Maps.of("SetName", "VolumeUnitTypes",
                         "Label", "Volume",
-                        "Description", "Units of volume")));
+                        "Description", "Units of volume",
+                        "ObjectId", UUID.randomUUID().toString())));
 
         command.setRows(lookupSetRows);
 
@@ -976,28 +981,36 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         List<Map<String, Object>> lookupRows = Arrays.asList(
                 new HashMap<>(Maps.of("LookupSetId", data.get(0).get("lookupSetId"),
                         "Value", "Research",
-                        "Displayable", "true")),
+                        "Displayable", "true",
+                        "ObjectId", UUID.randomUUID().toString())),
                 new HashMap<>(Maps.of("LookupSetId", data.get(0).get("lookupSetId"),
                         "Value", "Clinical",
-                        "Displayable", "true")),
+                        "Displayable", "true",
+                        "ObjectId", UUID.randomUUID().toString())),
                 new HashMap<>(Maps.of("LookupSetId", data.get(1).get("lookupSetId"),
                         "Value", "Research Blood Draw",
-                        "Displayable", "true")),
+                        "Displayable", "true",
+                        "ObjectId", UUID.randomUUID().toString())),
                 new HashMap<>(Maps.of("LookupSetId", data.get(1).get("lookupSetId"),
                         "Value", "Clinical Blood Draw",
-                        "Displayable", "true")),
+                        "Displayable", "true",
+                        "ObjectId", UUID.randomUUID().toString())),
                 new HashMap<>(Maps.of("LookupSetId", data.get(2).get("lookupSetId"),
                         "Value", "Male",
-                        "Displayable", "true")),
+                        "Displayable", "true",
+                        "ObjectId", UUID.randomUUID().toString())),
                 new HashMap<>(Maps.of("LookupSetId", data.get(2).get("lookupSetId"),
                         "Value", "Female",
-                        "Displayable", "true")),
+                        "Displayable", "true",
+                        "ObjectId", UUID.randomUUID().toString())),
                 new HashMap<>(Maps.of("LookupSetId", data.get(3).get("lookupSetId"),
                         "Value", "mL",
-                        "Displayable", "true")),
+                        "Displayable", "true",
+                        "ObjectId", UUID.randomUUID().toString())),
                 new HashMap<>(Maps.of("LookupSetId", data.get(3).get("lookupSetId"),
                         "Value", "L",
-                        "Displayable", "true")));
+                        "Displayable", "true",
+                        "ObjectId", UUID.randomUUID().toString())));
 
         command = new InsertRowsCommand("snd", "Lookups");
         command.setRows(lookupRows);


### PR DESCRIPTION
#### Rationale
Truncating lookup tables can cause SND data to be orphaned without FK associations to the lookups.  These triggers throw errors in the init batch trigger.  Throwing the error is the only way to have a custom error in these batch triggers.

#### Related Pull Requests
* https://github.com/LabKey/snprcEHRModules/pull/370

#### Changes
* Add LookupSets.js with init trigger to prevent truncate
* Move Lookups.js from SNPRC to SND and add init trigger to prevent trigger.  Convert Lookups.js from EHR to standard LK trigger
