### PR TITLE
 SecurityManager.getPermissions()

### DIFF
--- a/api-src/org/labkey/api/snd/Category.java
+++ b/api-src/org/labkey/api/snd/Category.java
@@ -22,10 +22,7 @@ import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.HasPermission;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
-import org.labkey.api.security.UserPrincipal;
-import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.util.GUID;
 
 import java.util.List;

--- a/api-src/org/labkey/api/snd/Category.java
+++ b/api-src/org/labkey/api/snd/Category.java
@@ -135,10 +135,4 @@ public class Category implements SecurableResource, HasPermission
     {
         return false;
     }
-
-    @Override
-    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
-    {
-        return SecurityPolicyManager.getPolicy(this).hasPermission("User does not have permission", user, perm);
-    }
 }


### PR DESCRIPTION
#### Rationale
Create new permission check choke-point.  Replace/unify Container.hasPermission() and SecurityPolicy.hasPermission()
* SecurityManager.hasAllPermissions()
* SecurityManager.hasAnyPermissions()
* SecurityManager.getPermissions()
* SecurityManager.getPermissionNames()

#### Related Pull Requests
* https://github.com/LabKey/compliance/pull/118
* https://github.com/LabKey/ehrModules/pull/195
* https://github.com/LabKey/snd/pull/97
* https://github.com/LabKey/platform/pull/2359
* https://github.com/LabKey/MacCossLabModules/pull/122
* https://github.com/LabKey/wnprc-modules/pull/86

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
