### PR TITLE
Updates for SND lookups editing

### DIFF
--- a/resources/queries/snd/LookupSets.js
+++ b/resources/queries/snd/LookupSets.js
@@ -1,8 +1,39 @@
-
+var console = require("console");
+var LABKEY = require("labkey");
 
 function init(event){
 
     if (event === 'truncate') {
         throw "Not allowed to truncate snd.LookupSets. Truncating this table can orphan lookup values in snd data.";
+    }
+}
+
+function beforeInsert(row, errors) {
+    row.objectId = row.objectId || LABKEY.Utils.generateUUID().toUpperCase();
+}
+
+function beforeDelete(row, errors) {
+
+    if (row.LookupSetId !== undefined) {
+        LABKEY.Query.selectRows({
+            schemaName: 'snd',
+            queryName: 'Lookups',
+            columns: 'LookupSetId',
+            scope: this,
+            filterArray: [
+                LABKEY.Filter.create('LookupSetId', row.LookupSetId, LABKEY.Filter.Types.EQUAL),
+
+            ],
+            success: function (data) {
+                if (data.rows && data.rows.length) {
+                    errors._form = 'LookupSet is in use and cannot be deleted'
+                    return;
+                }
+            },
+            failure: function (error) {
+                console.log('Select rows error');
+                console.log(error);
+            }
+        });
     }
 }

--- a/resources/queries/snd/Lookups.js
+++ b/resources/queries/snd/Lookups.js
@@ -1,5 +1,3 @@
-
-
 var console = require("console");
 var LABKEY = require("labkey");
 
@@ -11,7 +9,7 @@ function init(event){
 }
 
 function onUpsert(row, errors) {
-
+    // reuse LookupSetId if the SetName already exists. This primarily happens during ETLs
     if (row.LookupSetId === undefined || row.LookupSetId == 'undefined') {
         LABKEY.Query.selectRows({
             schemaName: 'snd',
@@ -38,6 +36,7 @@ function onUpsert(row, errors) {
 }
 
 function beforeInsert(row, errors) {
+    row.objectId = row.objectId || LABKEY.Utils.generateUUID().toUpperCase();
     onUpsert(row, errors);
 }
 
@@ -45,4 +44,62 @@ function beforeUpdate(row, errors) {
     onUpsert(row, errors);
 }
 
+function beforeDelete(row, errors) {
+/*
+    TODO: Need a better way to determine if a lookupset item is in use. Probably need to add the check to
+     the deleteRows method in LookupsTable.java. NOTE: CAMP allows the lookup item to be deleted if it hasn't
+     been assigned as a default value or used in an event. tjh
+ */
+    if (row.LookupSetId !== undefined) {
+
+        let lookupQuery
+
+        LABKEY.Query.selectRows({
+            schemaName: 'snd',
+            queryName: 'LookupSets',
+            columns: 'SetName',
+            scope: this,
+            filterArray: [
+                LABKEY.Filter.create('LookupSetId', row.LookupSetId, LABKEY.Filter.Types.EQUAL)
+            ],
+            success: function (data) {
+                if (data.rows && data.rows.length) {
+                    lookupQuery = data.rows[0].SetName
+                }
+                else {
+                    errors._form = 'LookupSet not found - shouldn\'t happen'
+                    return
+                }
+
+            },
+            failure: function (error) {
+                console.log('Select rows error');
+                console.log(error);
+            }
+        });
+
+
+        LABKEY.Query.selectRows({
+            schemaName: 'snd',
+            queryName: 'PackageAttribute',
+            columns: 'LookupQuery',
+            scope: this,
+            filterArray: [
+                LABKEY.Filter.create('LookupQuery', lookupQuery, LABKEY.Filter.Types.EQUAL),
+                LABKEY.Filter.create('LookupSchema', 'snd', LABKEY.Filter.Types.EQUAL)
+
+            ],
+            success: function (data) {
+                if (data.rows && data.rows.length) {
+                    errors._form = 'Lookup item cannot be deleted - LookupSet is in use.'
+                    return;
+                }
+            },
+            failure: function (error) {
+                console.log('Select rows error');
+                console.log(error);
+            }
+        });
+    }
+}
 

--- a/resources/schemas/snd.xml
+++ b/resources/schemas/snd.xml
@@ -296,7 +296,10 @@
             <column columnName="SetName"/>
             <column columnName="Label"/>
             <column columnName="Description"/>
-            <column columnName="ObjectId"/>
+            <column columnName="ObjectId">
+                <nullable>true</nullable>
+                <isReadOnly>true</isReadOnly>
+            </column>
             <column columnName="Container"/>
             <column columnName="CreatedBy"/>
             <column columnName="Created"/>
@@ -324,7 +327,10 @@
             <column columnName="Value"/>
             <column columnName="Displayable"/>
             <column columnName="SortOrder"/>
-            <column columnName="ObjectId"/>
+            <column columnName="ObjectId">
+                <nullable>true</nullable>
+                <isReadOnly>true</isReadOnly>
+            </column>
             <column columnName="Container"/>
             <column columnName="CreatedBy"/>
             <column columnName="Created"/>


### PR DESCRIPTION
#### Rationale
Updates for SND lookups editing

#### Related Pull Requests
None

#### Changes

fb_lookups
1. Updated JavaScript triggers to:
  -  prevent deletion of Lookups row if it is in use 
  -  prevent deletion of LookupSet row if it has lookup items in snd.Lookups
  -  programmatically add ObjectId to Lookups and LookupSets on inserts
2. Tweaked snd.xml to make the objectId in Lookups and LookupSets read-only
