### PR TITLE
Add contextual role for table access from APIs

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -61,6 +61,8 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
+import org.labkey.api.security.roles.FolderAdminRole;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.snd.AttributeData;
 import org.labkey.api.snd.Category;
@@ -129,7 +131,7 @@ public class SNDManager
 
     public static UserSchema getSndUserSchema(Container c, User u)
     {
-        return new SNDUserSchema(SNDSchema.NAME, null, u, c, SNDSchema.getInstance().getSchema(), false);
+        return new SNDUserSchema(SNDSchema.NAME, null, u, c, SNDSchema.getInstance().getSchema(), RoleManager.getRole(FolderAdminRole.class));
     }
 
     public static int MAX_MERGE_ROWS = 100000;

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -131,6 +131,11 @@ public class SNDManager
 
     public static UserSchema getSndUserSchema(Container c, User u)
     {
+        return new SNDUserSchema(SNDSchema.NAME, null, u, c, SNDSchema.getInstance().getSchema());
+    }
+
+    public static UserSchema getSndUserSchemaAdminRole(Container c, User u)
+    {
         return new SNDUserSchema(SNDSchema.NAME, null, u, c, SNDSchema.getInstance().getSchema(), RoleManager.getRole(FolderAdminRole.class));
     }
 
@@ -1712,7 +1717,7 @@ public class SNDManager
      */
     private EventData getEventData(Container c, User u, @Nullable Integer eventDataId, @NotNull SuperPackage superPackage, BatchValidationException errors)
     {
-        UserSchema schema = getSndUserSchema(c, u);
+        UserSchema schema = getSndUserSchemaAdminRole(c, u);
         TableInfo eventDataTable = getTableInfo(schema, SNDSchema.EVENTDATA_TABLE_NAME);
 
         Map<String, ObjectProperty> properties = null;
@@ -1846,7 +1851,7 @@ public class SNDManager
     @Nullable
     public Event getEvent(Container c, User u, int eventId, Set<EventNarrativeOption> narrativeOptions, @Nullable Map<Integer, SuperPackage> topLevelEventDataSuperPkgs, boolean skipPermissionCheck, BatchValidationException errors)
     {
-        UserSchema schema = getSndUserSchema(c, u);
+        UserSchema schema = getSndUserSchemaAdminRole(c, u);
 
         TableInfo eventsTable = getTableInfo(schema, SNDSchema.EVENTS_TABLE_NAME);
 
@@ -1910,7 +1915,7 @@ public class SNDManager
     private Map<EventNarrativeOption, String> getNarratives(Container c, User u, Set<EventNarrativeOption> narrativeOptions, Map<Integer, SuperPackage> topLevelEventDataSuperPkgs, Event event, BatchValidationException errors)
     {
         Map<EventNarrativeOption, String> narratives = null;
-        UserSchema schema = getSndUserSchema(c, u);
+        UserSchema schema = getSndUserSchemaAdminRole(c, u);
         SimpleFilter eventFilter = new SimpleFilter(FieldKey.fromParts("EventId"), event.getEventId(), CompareType.EQUAL);
 
         if (narrativeOptions != null)
@@ -2098,7 +2103,7 @@ public class SNDManager
      */
     public void deleteEventNotes(Container c, User u, int eventId) throws SQLException, QueryUpdateServiceException, BatchValidationException, InvalidKeyException
     {
-        UserSchema schema = getSndUserSchema(c, u);
+        UserSchema schema = getSndUserSchemaAdminRole(c, u);
 
         SQLFragment sql = new SQLFragment("SELECT EventNoteId FROM ");
         sql.append(schema.getTable(SNDSchema.EVENTNOTES_TABLE_NAME), "en");
@@ -2312,7 +2317,7 @@ public class SNDManager
      */
     private void insertEventDatas(Container c, User u, Event event, BatchValidationException errors) throws ValidationException, SQLException, QueryUpdateServiceException, BatchValidationException, DuplicateKeyException
     {
-        UserSchema schema = getSndUserSchema(c, u);
+        UserSchema schema = getSndUserSchemaAdminRole(c, u);
         TableInfo eventDataTable = getTableInfo(schema, SNDSchema.EVENTDATA_TABLE_NAME);
 
         QueryUpdateService eventDataQus = getNewQueryUpdateService(schema, SNDSchema.EVENTDATA_TABLE_NAME);
@@ -2529,7 +2534,7 @@ public class SNDManager
 
                             if (!event.hasErrors() && !validateOnly)
                             {
-                                UserSchema schema = getSndUserSchema(c, u);
+                                UserSchema schema = getSndUserSchemaAdminRole(c, u);
                                 TableInfo eventTable = getTableInfo(schema, SNDSchema.EVENTS_TABLE_NAME);
                                 QueryUpdateService eventQus = getQueryUpdateService(eventTable);
                                 QueryUpdateService eventsCacheQus = getNewQueryUpdateService(schema, SNDSchema.EVENTSCACHE_TABLE_NAME);
@@ -2600,7 +2605,7 @@ public class SNDManager
      */
     public void deleteEventsCache(Container c, User u, int eventId) throws SQLException, QueryUpdateServiceException, BatchValidationException, InvalidKeyException
     {
-        UserSchema schema = getSndUserSchema(c, u);
+        UserSchema schema = getSndUserSchemaAdminRole(c, u);
 
         QueryUpdateService eventsCacheQus = getNewQueryUpdateService(schema, SNDSchema.EVENTSCACHE_TABLE_NAME);
 
@@ -2615,7 +2620,7 @@ public class SNDManager
      */
     public void deleteEventDatas(Container c, User u, int eventId) throws SQLException, QueryUpdateServiceException, BatchValidationException, InvalidKeyException
     {
-        UserSchema schema = getSndUserSchema(c, u);
+        UserSchema schema = getSndUserSchemaAdminRole(c, u);
 
         SQLFragment sql = new SQLFragment("SELECT EventDataId FROM ");
         sql.append(schema.getTable(SNDSchema.EVENTDATA_TABLE_NAME), "ed");
@@ -2645,7 +2650,7 @@ public class SNDManager
      */
     private void deleteExpObjects(Container c, User u, int eventId)
     {
-        UserSchema schema = getSndUserSchema(c, u);
+        UserSchema schema = getSndUserSchemaAdminRole(c, u);
         TableInfo eventDataTable = getTableInfo(schema, SNDSchema.EVENTDATA_TABLE_NAME);
 
         // Get from eventNotes table
@@ -2693,7 +2698,7 @@ public class SNDManager
 
                             if (!event.hasErrors() && !validateOnly)
                             {
-                                UserSchema schema = getSndUserSchema(c, u);
+                                UserSchema schema = getSndUserSchemaAdminRole(c, u);
                                 TableInfo eventTable = getTableInfo(schema, SNDSchema.EVENTS_TABLE_NAME);
                                 QueryUpdateService eventQus = getQueryUpdateService(eventTable);
                                 QueryUpdateService eventNotesQus = null;
@@ -2805,7 +2810,7 @@ public class SNDManager
      */
     public void deleteNarrativeCacheRows(Container c, User u, List<Map<String, Object>> eventIds, BatchValidationException errors)
     {
-        UserSchema sndSchema = getSndUserSchema(c, u);
+        UserSchema sndSchema = getSndUserSchemaAdminRole(c, u);
         QueryUpdateService eventsCacheQus = getNewQueryUpdateService(sndSchema, SNDSchema.EVENTSCACHE_TABLE_NAME);
 
         try
@@ -2823,7 +2828,7 @@ public class SNDManager
      */
     public void clearNarrativeCache(Container c, User u, BatchValidationException errors)
     {
-        UserSchema sndSchema = getSndUserSchema(c, u);
+        UserSchema sndSchema = getSndUserSchemaAdminRole(c, u);
         QueryUpdateService eventsCacheQus = getNewQueryUpdateService(sndSchema, SNDSchema.EVENTSCACHE_TABLE_NAME);
 
         try (DbScope.Transaction tx = sndSchema.getDbSchema().getScope().ensureTransaction())
@@ -2842,7 +2847,7 @@ public class SNDManager
      */
     public void fillInNarrativeCache(Container c, User u, BatchValidationException errors, @Nullable Logger logger)
     {
-        UserSchema sndSchema = getSndUserSchema(c, u);
+        UserSchema sndSchema = getSndUserSchemaAdminRole(c, u);
 
         SQLFragment eventSql = new SQLFragment("SELECT ev.EventId FROM ");
         eventSql.append(sndSchema.getTable(SNDSchema.EVENTS_TABLE_NAME), "ev");
@@ -2871,7 +2876,7 @@ public class SNDManager
      */
     public void populateNarrativeCache(Container c, User u, List<Map<String, Object>> eventIds, BatchValidationException errors, @Nullable Logger logger)
     {
-        UserSchema sndSchema = getSndUserSchema(c, u);
+        UserSchema sndSchema = getSndUserSchemaAdminRole(c, u);
         QueryUpdateService eventsCacheQus = getNewQueryUpdateService(sndSchema, SNDSchema.EVENTSCACHE_TABLE_NAME);
 
         Map<Integer, SuperPackage> eventDataTopLevelSuperPkgs;
@@ -2929,7 +2934,7 @@ public class SNDManager
      */
     private Map<Integer, SuperPackage> getTopLevelEventDataSuperPkgs(Container c, User u, int eventId, BatchValidationException errors)
     {
-        UserSchema schema = getSndUserSchema(c, u);
+        UserSchema schema = getSndUserSchemaAdminRole(c, u);
 
         SQLFragment sql = new SQLFragment("SELECT SuperPkgId, EventDataId FROM ");
         sql.append(schema.getTable(SNDSchema.EVENTDATA_TABLE_NAME), "ed");

--- a/src/org/labkey/snd/SNDUserSchema.java
+++ b/src/org/labkey/snd/SNDUserSchema.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.snd;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
@@ -26,6 +27,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.roles.Role;
 import org.labkey.snd.query.AttributeDataTable;
@@ -46,7 +48,7 @@ import java.util.Map;
 import java.util.Set;
 
 
-public class SNDUserSchema extends SimpleUserSchema
+public class SNDUserSchema extends SimpleUserSchema implements UserSchema.HasContextualRoles
 {
     private final Role _contextualRole;
 
@@ -62,9 +64,10 @@ public class SNDUserSchema extends SimpleUserSchema
         _contextualRole = contextualRole;
     }
 
-    public Role getContextualRole()
+    @Override
+    public @NotNull Set<Role> getContextualRoles()
     {
-        return _contextualRole;
+        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
     }
 
     public enum TableType
@@ -139,7 +142,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new EventNotesTable(schema, SNDSchema.getInstance().getTableInfoEventNotes(), cf, schema.getContextualRole()).init();
+                        return new EventNotesTable(schema, SNDSchema.getInstance().getTableInfoEventNotes(), cf).init();
                     }
                 },
         EventData
@@ -147,7 +150,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new EventDataTable(schema, SNDSchema.getInstance().getTableInfoEventData(), cf, schema.getContextualRole()).init();
+                        return new EventDataTable(schema, SNDSchema.getInstance().getTableInfoEventData(), cf).init();
                     }
                 },
         AttributeData
@@ -155,7 +158,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new AttributeDataTable(schema, cf, schema.getContextualRole());
+                        return new AttributeDataTable(schema, cf);
                     }
                 },
         PackageAttribute
@@ -163,7 +166,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new PackageAttributeTable(schema, cf, schema.getContextualRole());
+                        return new PackageAttributeTable(schema, cf);
                     }
                 },
         Lookups
@@ -191,7 +194,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new EventsCacheTable(schema, SNDSchema.getInstance().getTableInfoEventsCache(), cf, schema.getContextualRole()).init();
+                        return new EventsCacheTable(schema, SNDSchema.getInstance().getTableInfoEventsCache(), cf).init();
                     }
                 };
 

--- a/src/org/labkey/snd/SNDUserSchema.java
+++ b/src/org/labkey/snd/SNDUserSchema.java
@@ -27,7 +27,7 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.snd.query.AttributeDataTable;
 import org.labkey.snd.query.CategoriesTable;
 import org.labkey.snd.query.EventDataTable;
@@ -48,22 +48,23 @@ import java.util.Set;
 
 public class SNDUserSchema extends SimpleUserSchema
 {
-    private boolean _permissionCheck = true;
+    private final Role _contextualRole;
 
     public SNDUserSchema(String name, @Nullable String description, User user, Container container, DbSchema dbschema)
     {
         super(name, description, user, container, dbschema);
+        _contextualRole = null;
     }
 
-    public SNDUserSchema(String name, @Nullable String description, User user, Container container, DbSchema dbschema, boolean permissionCheck)
+    public SNDUserSchema(String name, @Nullable String description, User user, Container container, DbSchema dbschema, Role contextualRole)
     {
         super(name, description, user, container, dbschema);
-        _permissionCheck = permissionCheck;
+        _contextualRole = contextualRole;
     }
 
-    public boolean getPermissionCheck()
+    public Role getContextualRole()
     {
-        return _permissionCheck;
+        return _contextualRole;
     }
 
     public enum TableType
@@ -138,12 +139,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        if (!schema.getPermissionCheck() || schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class))
-                        {
-                            return new EventNotesTable(schema, SNDSchema.getInstance().getTableInfoEventNotes(), cf).init();
-                        }
-
-                        return null;
+                        return new EventNotesTable(schema, SNDSchema.getInstance().getTableInfoEventNotes(), cf, schema.getContextualRole()).init();
                     }
                 },
         EventData
@@ -151,12 +147,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        if (!schema.getPermissionCheck() || schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class))
-                        {
-                            return new EventDataTable(schema, SNDSchema.getInstance().getTableInfoEventData(), cf).init();
-                        }
-
-                        return null;
+                        return new EventDataTable(schema, SNDSchema.getInstance().getTableInfoEventData(), cf, schema.getContextualRole()).init();
                     }
                 },
         AttributeData
@@ -164,12 +155,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        if (!schema.getPermissionCheck() || schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class))
-                        {
-                            return new AttributeDataTable(schema, cf);
-                        }
-
-                        return null;
+                        return new AttributeDataTable(schema, cf, schema.getContextualRole());
                     }
                 },
         PackageAttribute
@@ -177,12 +163,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        if (!schema.getPermissionCheck() || schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class))
-                        {
-                            return new PackageAttributeTable(schema, cf);
-                        }
-
-                        return null;
+                        return new PackageAttributeTable(schema, cf, schema.getContextualRole());
                     }
                 },
         Lookups
@@ -210,12 +191,7 @@ public class SNDUserSchema extends SimpleUserSchema
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        if (!schema.getPermissionCheck() || schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class))
-                        {
-                            return new EventsCacheTable(schema, SNDSchema.getInstance().getTableInfoEventsCache(), cf).init();
-                        }
-
-                        return null;
+                        return new EventsCacheTable(schema, SNDSchema.getInstance().getTableInfoEventsCache(), cf, schema.getContextualRole()).init();
                     }
                 };
 

--- a/src/org/labkey/snd/SNDUserSchema.java
+++ b/src/org/labkey/snd/SNDUserSchema.java
@@ -29,6 +29,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.snd.query.AttributeDataTable;
 import org.labkey.snd.query.CategoriesTable;
@@ -142,7 +143,12 @@ public class SNDUserSchema extends SimpleUserSchema implements UserSchema.HasCon
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new EventNotesTable(schema, SNDSchema.getInstance().getTableInfoEventNotes(), cf).init();
+                        if (schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class, schema.getContextualRoles()))
+                        {
+                            return new EventNotesTable(schema, SNDSchema.getInstance().getTableInfoEventNotes(), cf).init();
+                        }
+
+                        return null;
                     }
                 },
         EventData
@@ -150,7 +156,12 @@ public class SNDUserSchema extends SimpleUserSchema implements UserSchema.HasCon
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new EventDataTable(schema, SNDSchema.getInstance().getTableInfoEventData(), cf).init();
+                        if (schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class, schema.getContextualRoles()))
+                        {
+                            return new EventDataTable(schema, SNDSchema.getInstance().getTableInfoEventData(), cf).init();
+                        }
+
+                        return null;
                     }
                 },
         AttributeData
@@ -158,7 +169,12 @@ public class SNDUserSchema extends SimpleUserSchema implements UserSchema.HasCon
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new AttributeDataTable(schema, cf);
+                        if (schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class, schema.getContextualRoles()))
+                        {
+                            return new AttributeDataTable(schema, cf);
+                        }
+
+                        return null;
                     }
                 },
         PackageAttribute
@@ -166,7 +182,12 @@ public class SNDUserSchema extends SimpleUserSchema implements UserSchema.HasCon
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new PackageAttributeTable(schema, cf);
+                        if (schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class, schema.getContextualRoles()))
+                        {
+                            return new PackageAttributeTable(schema, cf);
+                        }
+
+                        return null;
                     }
                 },
         Lookups
@@ -194,7 +215,12 @@ public class SNDUserSchema extends SimpleUserSchema implements UserSchema.HasCon
                     @Override
                     public TableInfo createTable(SNDUserSchema schema, ContainerFilter cf)
                     {
-                        return new EventsCacheTable(schema, SNDSchema.getInstance().getTableInfoEventsCache(), cf).init();
+                        if (schema.getContainer().hasPermission(schema.getUser(), AdminPermission.class, schema.getContextualRoles()))
+                        {
+                            return new EventsCacheTable(schema, SNDSchema.getInstance().getTableInfoEventsCache(), cf).init();
+                        }
+
+                        return null;
                     }
                 };
 

--- a/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/src/org/labkey/snd/query/AttributeDataTable.java
@@ -46,7 +46,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.roles.Role;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.snd.SNDService;
 import org.labkey.api.util.UnexpectedException;
@@ -69,12 +68,9 @@ import java.util.Set;
  */
 public class AttributeDataTable extends FilteredTable<SNDUserSchema>
 {
-    private final Role _contextualRole;
-
-    public AttributeDataTable(@NotNull SNDUserSchema userSchema, ContainerFilter cf, Role contextualRole)
+    public AttributeDataTable(@NotNull SNDUserSchema userSchema, ContainerFilter cf)
     {
         super(OntologyManager.getTinfoObjectProperty(), userSchema, cf);
-        _contextualRole = contextualRole;
 
         setName(SNDUserSchema.TableType.AttributeData.name());
         setDescription("Event/package attribute data, one row per attribute/value combination.");
@@ -139,15 +135,10 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
         return sql;
     }
 
-    public @NotNull Set<Role> getContextualRoles()
-    {
-        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
-    }
-
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
+        return getContainer().hasPermission(user, AdminPermission.class, getUserSchema().getContextualRoles());
     }
 
     @Override

--- a/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/src/org/labkey/snd/query/AttributeDataTable.java
@@ -46,6 +46,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.snd.SNDService;
 import org.labkey.api.util.UnexpectedException;
@@ -68,9 +69,13 @@ import java.util.Set;
  */
 public class AttributeDataTable extends FilteredTable<SNDUserSchema>
 {
-    public AttributeDataTable(@NotNull SNDUserSchema userSchema, ContainerFilter cf)
+    private final Role _contextualRole;
+
+    public AttributeDataTable(@NotNull SNDUserSchema userSchema, ContainerFilter cf, Role contextualRole)
     {
         super(OntologyManager.getTinfoObjectProperty(), userSchema, cf);
+        _contextualRole = contextualRole;
+
         setName(SNDUserSchema.TableType.AttributeData.name());
         setDescription("Event/package attribute data, one row per attribute/value combination.");
 
@@ -134,10 +139,15 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
         return sql;
     }
 
+    public @NotNull Set<Role> getContextualRoles()
+    {
+        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
+    }
+
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class);
+        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
     }
 
     @Override

--- a/src/org/labkey/snd/query/EventDataTable.java
+++ b/src/org/labkey/snd/query/EventDataTable.java
@@ -39,7 +39,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.roles.Role;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.snd.SNDService;
 import org.labkey.snd.SNDManager;
@@ -54,8 +53,6 @@ import java.util.Set;
 
 public class EventDataTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 {
-    private final Role _contextualRole;
-
     /**
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
@@ -63,21 +60,15 @@ public class EventDataTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
      * @param schema
      * @param table
      */
-    public EventDataTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf, Role contextualRole)
+    public EventDataTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
     {
         super(schema, table, cf);
-        _contextualRole = contextualRole;
-    }
-
-    public @NotNull Set<Role> getContextualRoles()
-    {
-        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
     }
 
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
+        return getContainer().hasPermission(user, AdminPermission.class, getUserSchema().getContextualRoles());
     }
 
     @Override

--- a/src/org/labkey/snd/query/EventDataTable.java
+++ b/src/org/labkey/snd/query/EventDataTable.java
@@ -39,6 +39,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.snd.SNDService;
 import org.labkey.snd.SNDManager;
@@ -53,6 +54,8 @@ import java.util.Set;
 
 public class EventDataTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 {
+    private final Role _contextualRole;
+
     /**
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
@@ -60,15 +63,21 @@ public class EventDataTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
      * @param schema
      * @param table
      */
-    public EventDataTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
+    public EventDataTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf, Role contextualRole)
     {
         super(schema, table, cf);
+        _contextualRole = contextualRole;
+    }
+
+    public @NotNull Set<Role> getContextualRoles()
+    {
+        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
     }
 
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class);
+        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
     }
 
     @Override

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -31,6 +31,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.snd.SNDService;
 import org.labkey.snd.SNDManager;
 import org.labkey.snd.SNDUserSchema;
@@ -38,9 +39,12 @@ import org.labkey.snd.SNDUserSchema;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 {
+    private final Role _contextualRole;
+
     /**
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
@@ -48,9 +52,10 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
      * @param schema
      * @param table
      */
-    public EventNotesTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
+    public EventNotesTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf, Role contextualRole)
     {
         super(schema, table, cf);
+        _contextualRole = contextualRole;
     }
 
     @Override
@@ -110,9 +115,14 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 
     }
 
+    public @NotNull Set<Role> getContextualRoles()
+    {
+        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
+    }
+
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class);
+        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
     }
 }

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -31,7 +31,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.roles.Role;
 import org.labkey.api.snd.SNDService;
 import org.labkey.snd.SNDManager;
 import org.labkey.snd.SNDUserSchema;
@@ -39,12 +38,9 @@ import org.labkey.snd.SNDUserSchema;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 {
-    private final Role _contextualRole;
-
     /**
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
@@ -52,10 +48,9 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
      * @param schema
      * @param table
      */
-    public EventNotesTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf, Role contextualRole)
+    public EventNotesTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
     {
         super(schema, table, cf);
-        _contextualRole = contextualRole;
     }
 
     @Override
@@ -115,14 +110,9 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 
     }
 
-    public @NotNull Set<Role> getContextualRoles()
-    {
-        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
-    }
-
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
+        return getContainer().hasPermission(user, AdminPermission.class, getUserSchema().getContextualRoles());
     }
 }

--- a/src/org/labkey/snd/query/EventsCacheTable.java
+++ b/src/org/labkey/snd/query/EventsCacheTable.java
@@ -24,14 +24,18 @@ import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.snd.SNDUserSchema;
 import org.labkey.snd.table.PlainTextNarrativeDisplayColumn;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class EventsCacheTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 {
+    private final Role _contextualRole;
+
     /**
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
@@ -39,9 +43,10 @@ public class EventsCacheTable extends SimpleUserSchema.SimpleTable<SNDUserSchema
      * @param schema
      * @param table
      */
-    public EventsCacheTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
+    public EventsCacheTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf, Role contextualRole)
     {
         super(schema, table, cf);
+        _contextualRole = contextualRole;
     }
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
@@ -53,10 +58,15 @@ public class EventsCacheTable extends SimpleUserSchema.SimpleTable<SNDUserSchema
         defaultVisibleColumns.add(FieldKey.fromParts("Plain Text Narrative"));
     }
 
+    public @NotNull Set<Role> getContextualRoles()
+    {
+        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
+    }
+
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class);
+        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
     }
 
     @Override

--- a/src/org/labkey/snd/query/EventsCacheTable.java
+++ b/src/org/labkey/snd/query/EventsCacheTable.java
@@ -24,18 +24,14 @@ import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.roles.Role;
 import org.labkey.snd.SNDUserSchema;
 import org.labkey.snd.table.PlainTextNarrativeDisplayColumn;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 public class EventsCacheTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 {
-    private final Role _contextualRole;
-
     /**
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
@@ -43,10 +39,9 @@ public class EventsCacheTable extends SimpleUserSchema.SimpleTable<SNDUserSchema
      * @param schema
      * @param table
      */
-    public EventsCacheTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf, Role contextualRole)
+    public EventsCacheTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
     {
         super(schema, table, cf);
-        _contextualRole = contextualRole;
     }
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
@@ -58,15 +53,10 @@ public class EventsCacheTable extends SimpleUserSchema.SimpleTable<SNDUserSchema
         defaultVisibleColumns.add(FieldKey.fromParts("Plain Text Narrative"));
     }
 
-    public @NotNull Set<Role> getContextualRoles()
-    {
-        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
-    }
-
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
+        return getContainer().hasPermission(user, AdminPermission.class, getUserSchema().getContextualRoles());
     }
 
     @Override

--- a/src/org/labkey/snd/query/PackageAttributeTable.java
+++ b/src/org/labkey/snd/query/PackageAttributeTable.java
@@ -27,6 +27,7 @@ import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.snd.PackageDomainKind;
 import org.labkey.api.util.HtmlString;
 import org.labkey.snd.SNDManager;
@@ -38,12 +39,17 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class PackageAttributeTable extends FilteredTable<SNDUserSchema>
 {
-    public PackageAttributeTable(@NotNull SNDUserSchema userSchema, ContainerFilter cf)
+    private final Role _contextualRole;
+
+    public PackageAttributeTable(@NotNull SNDUserSchema userSchema, ContainerFilter cf, Role contextualRole)
     {
         super(OntologyManager.getTinfoPropertyDescriptor(), userSchema, cf);
+        _contextualRole = contextualRole;
+
         setName(SNDUserSchema.TableType.PackageAttribute.name());
         setDescription("Package/attributes, one row per package/attribute combination.");
 
@@ -247,10 +253,15 @@ public class PackageAttributeTable extends FilteredTable<SNDUserSchema>
         return sql;
     }
 
+    public @NotNull Set<Role> getContextualRoles()
+    {
+        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
+    }
+
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class);
+        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
     }
 
 }

--- a/src/org/labkey/snd/query/PackageAttributeTable.java
+++ b/src/org/labkey/snd/query/PackageAttributeTable.java
@@ -27,7 +27,6 @@ import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.roles.Role;
 import org.labkey.api.snd.PackageDomainKind;
 import org.labkey.api.util.HtmlString;
 import org.labkey.snd.SNDManager;
@@ -39,16 +38,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class PackageAttributeTable extends FilteredTable<SNDUserSchema>
 {
-    private final Role _contextualRole;
-
-    public PackageAttributeTable(@NotNull SNDUserSchema userSchema, ContainerFilter cf, Role contextualRole)
+    public PackageAttributeTable(@NotNull SNDUserSchema userSchema, ContainerFilter cf)
     {
         super(OntologyManager.getTinfoPropertyDescriptor(), userSchema, cf);
-        _contextualRole = contextualRole;
 
         setName(SNDUserSchema.TableType.PackageAttribute.name());
         setDescription("Package/attributes, one row per package/attribute combination.");
@@ -253,15 +248,10 @@ public class PackageAttributeTable extends FilteredTable<SNDUserSchema>
         return sql;
     }
 
-    public @NotNull Set<Role> getContextualRoles()
-    {
-        return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
-    }
-
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, AdminPermission.class, getContextualRoles());
+        return getContainer().hasPermission(user, AdminPermission.class, getUserSchema().getContextualRoles());
     }
 
 }

--- a/src/org/labkey/snd/security/SNDSecurityManager.java
+++ b/src/org/labkey/snd/security/SNDSecurityManager.java
@@ -20,7 +20,6 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.CoreSchema;
-import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Table;
@@ -304,7 +303,7 @@ public class SNDSecurityManager
     {
         TableInfo qcStateTable = CoreSchema.getInstance().getTableInfoDataStates();
 
-        SimpleFilter qcFilter = new SimpleFilter(FieldKey.fromParts("Label"), qcState.getName(), CompareType.EQUAL);
+        SimpleFilter qcFilter = SimpleFilter.createContainerFilter(c).addCondition(FieldKey.fromParts("Label"), qcState.getName(), CompareType.EQUAL);
 
         // Get from eventNotes table
         Set<String> cols = new HashSet<>();
@@ -318,7 +317,7 @@ public class SNDSecurityManager
     {
         TableInfo qcStateTable = CoreSchema.getInstance().getTableInfoDataStates();
 
-        SimpleFilter qcFilter = new SimpleFilter(FieldKey.fromParts("RowId"), qcStateId, CompareType.EQUAL);
+        SimpleFilter qcFilter = SimpleFilter.createContainerFilter(c).addCondition(FieldKey.fromParts("RowId"), qcStateId, CompareType.EQUAL);
 
         // Get from eventNotes table
         Set<String> cols = new HashSet<>();


### PR DESCRIPTION
#### Rationale
Related PR refactor now calls tableInfo.hasPermission before executing fromSQL.  Added a contextual role for API usage of the tables that normally require admin access.  Also fix issue 44274, container filtering on QCStates in SNDSecurityManager.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2746

#### Changes
* Add contextual role to SNDUserSchema
* Use admin contextual role in SNDManager when querying admin only tables
* Add container filtering for QCStates in SNDSecurityManager, Issue #44274
