### PR TITLE
Don't use HashSet for column lists

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -91,7 +91,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1882,8 +1881,7 @@ public class SNDManager
                     TableInfo eventNotesTable = getTableInfo(schema, SNDSchema.EVENTNOTES_TABLE_NAME);
 
                     // Get from eventNotes table
-                    Set<String> cols = new HashSet<>();
-                    cols.add("Note");
+                    Set<String> cols = Collections.singleton("Note");
                     TableSelector eventNoteTs = new TableSelector(eventNotesTable, cols, eventFilter, null);
 
                     event.setNote(eventNoteTs.getObject(String.class));
@@ -2655,8 +2653,7 @@ public class SNDManager
 
         // Get from eventNotes table
         SimpleFilter eventDataFilter = new SimpleFilter(FieldKey.fromParts("EventId"), eventId, CompareType.EQUAL);
-        Set<String> cols = new HashSet<>();
-        cols.add("ObjectURI");
+        Set<String> cols = Collections.singleton("ObjectURI");
         TableSelector eventDataTs = new TableSelector(eventDataTable, cols, eventDataFilter, null);
 
         List<String> objectURIs = eventDataTs.getArrayList(String.class);

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -77,6 +77,7 @@ import org.labkey.api.snd.SNDDomainKind;
 import org.labkey.api.snd.SNDSequencer;
 import org.labkey.api.snd.SuperPackage;
 import org.labkey.api.util.DateUtil;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.snd.query.PackagesTable;
 import org.labkey.snd.security.QCStateActionEnum;
 import org.labkey.snd.security.SNDSecurityManager;
@@ -2355,9 +2356,7 @@ public class SNDManager
 
             // Get from project items table
             SimpleFilter projectItemsFilter = new SimpleFilter(FieldKey.fromParts("ParentObjectId"), event.getParentObjectId(), CompareType.EQUAL);
-            Set<String> cols = new TreeSet<>();
-            cols.add("SuperPkgId");
-            cols.add("Active");
+            Set<String> cols = PageFlowUtil.set("SuperPkgId", "Active");
             TableSelector projectItemsTs = new TableSelector(projectItemsTable, cols, projectItemsFilter, null);
 
             try (TableResultSet projectItems = projectItemsTs.getResultSet())

--- a/src/org/labkey/snd/query/PackagesTable.java
+++ b/src/org/labkey/snd/query/PackagesTable.java
@@ -52,6 +52,7 @@ import org.labkey.snd.SNDUserSchema;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -109,8 +110,7 @@ public class PackagesTable extends SimpleTable<SNDUserSchema>
 
     public boolean isPackageInUse(int pkgId)
     {
-        Set<String> cols = new HashSet<>();
-        cols.add("HasEvent");
+        Set<String> cols = Collections.singleton("HasEvent");
         TableSelector ts = new TableSelector(this, cols, new SimpleFilter(FieldKey.fromString("PkgId"), pkgId), null);
         Map<String, Object> ret = ts.getMap();
 
@@ -244,9 +244,9 @@ public class PackagesTable extends SimpleTable<SNDUserSchema>
                 Set<String> cols = new HashSet<>();
                 cols.add("HasEvent");
                 cols.add("HasProject");
-                TableSelector ts = new TableSelector(this.getQueryTable(), cols, new SimpleFilter(FieldKey.fromString("PkgId"), row.get("PkgId")), null);
-                row.put(Package.PKG_HASEVENT, Boolean.parseBoolean((String) ts.getMap().get(Package.PKG_HASEVENT)));
-                row.put(Package.PKG_HASPROJECT, Boolean.parseBoolean((String) ts.getMap().get(Package.PKG_HASPROJECT)));
+                Map<String, Object> map = new TableSelector(this.getQueryTable(), cols, new SimpleFilter(FieldKey.fromString("PkgId"), row.get("PkgId")), null).getMap();
+                row.put(Package.PKG_HASEVENT, Boolean.parseBoolean((String) map.get(Package.PKG_HASEVENT)));
+                row.put(Package.PKG_HASPROJECT, Boolean.parseBoolean((String) map.get(Package.PKG_HASPROJECT)));
             }
 
             return row;

--- a/src/org/labkey/snd/query/ProjectsTable.java
+++ b/src/org/labkey/snd/query/ProjectsTable.java
@@ -41,7 +41,7 @@ import org.labkey.snd.SNDSchema;
 import org.labkey.snd.SNDUserSchema;
 
 import java.sql.SQLException;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,8 +82,7 @@ public class ProjectsTable extends SimpleTable<SNDUserSchema>
 
     public boolean isProjectInUse(int projectId, int revNum)
     {
-        Set<String> cols = new HashSet<>();
-        cols.add("HasEvent");
+        Set<String> cols = Collections.singleton("HasEvent");
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("ProjectId"), projectId, CompareType.EQUAL);
         filter.addCondition(FieldKey.fromString("RevisionNum"), revNum, CompareType.EQUAL);
         TableSelector ts = new TableSelector(this, cols, filter, null);

--- a/src/org/labkey/snd/query/SuperPackagesTable.java
+++ b/src/org/labkey/snd/query/SuperPackagesTable.java
@@ -40,6 +40,7 @@ import org.labkey.snd.SNDUserSchema;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -101,12 +102,11 @@ public class SuperPackagesTable extends SimpleTable<SNDUserSchema>
 
     public boolean isPackageInUse(int superPkgId)
     {
-        Set<String> cols = new HashSet<>();
-        cols.add("HasEvent");
+        Set<String> cols = Collections.singleton("HasEvent");
         TableSelector ts = new TableSelector(this, cols, new SimpleFilter(FieldKey.fromString("SuperPkgId"), superPkgId), null);
-        Map<String, Object> ret = ts.getMap();
+        Map<String, Object> map = ts.getMap();
 
-        return Boolean.parseBoolean((String) ret.get("HasEvent"));
+        return Boolean.parseBoolean((String) map.get("HasEvent"));
     }
 
     @Override
@@ -181,6 +181,7 @@ public class SuperPackagesTable extends SimpleTable<SNDUserSchema>
             if(row == null)  // might have been deleted already due to package/super package cascading deletes
                 return null;
 
+            // TODO: Delete or complete this... TableSelector is unused!
             Set<String> cols = new HashSet<>();
             cols.add("HasEvent");
             cols.add("HasProject");

--- a/src/org/labkey/snd/query/SuperPackagesTable.java
+++ b/src/org/labkey/snd/query/SuperPackagesTable.java
@@ -42,7 +42,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -172,22 +171,6 @@ public class SuperPackagesTable extends SimpleTable<SNDUserSchema>
             }
 
             return super.deleteRow(user, container, oldRowMap);
-        }
-
-        @Override
-        protected Map<String, Object> getRow(User user, Container container, Map<String, Object> keys) throws InvalidKeyException, QueryUpdateServiceException, SQLException
-        {
-            Map<String, Object> row = super.getRow(user, container, keys);
-            if(row == null)  // might have been deleted already due to package/super package cascading deletes
-                return null;
-
-            // TODO: Delete or complete this... TableSelector is unused!
-            Set<String> cols = new HashSet<>();
-            cols.add("HasEvent");
-            cols.add("HasProject");
-            TableSelector ts = new TableSelector(this.getQueryTable(), cols, new SimpleFilter(FieldKey.fromString("SuperPkgId"), row.get("SuperPkgId")), null);
-
-            return row;
         }
 
         private TableInfo getTableInfo(@NotNull UserSchema schema, @NotNull String table)

--- a/src/org/labkey/snd/security/SNDSecurityManager.java
+++ b/src/org/labkey/snd/security/SNDSecurityManager.java
@@ -306,8 +306,7 @@ public class SNDSecurityManager
         SimpleFilter qcFilter = SimpleFilter.createContainerFilter(c).addCondition(FieldKey.fromParts("Label"), qcState.getName(), CompareType.EQUAL);
 
         // Get from eventNotes table
-        Set<String> cols = new HashSet<>();
-        cols.add("RowId");
+        Set<String> cols = Collections.singleton("RowId");
         TableSelector qcStateTs = new TableSelector(qcStateTable, cols, qcFilter, null);
 
         return qcStateTs.getObject(Integer.class);
@@ -320,8 +319,7 @@ public class SNDSecurityManager
         SimpleFilter qcFilter = SimpleFilter.createContainerFilter(c).addCondition(FieldKey.fromParts("RowId"), qcStateId, CompareType.EQUAL);
 
         // Get from eventNotes table
-        Set<String> cols = new HashSet<>();
-        cols.add("Label");
+        Set<String> cols = Collections.singleton("Label");
         TableSelector qcStateTs = new TableSelector(qcStateTable, cols, qcFilter, null);
 
         String qcStateName = qcStateTs.getObject(String.class);


### PR DESCRIPTION
#### Rationale
We're getting stricter about requiring stable-ordered column lists. See related PR for details. Also, fix a case of duplicate query execution.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3158