### PR TITLE
Increased default value of EventDataId in SNDSequencer

### DIFF
--- a/api-src/org/labkey/api/snd/SNDSequencer.java
+++ b/api-src/org/labkey/api/snd/SNDSequencer.java
@@ -27,7 +27,7 @@ public enum SNDSequencer
     PROJECTID ("org.labkey.snd.api.Project", 1000),
     PROJECTITEMID ("org.labkey.snd.api.ProjectItem", 30000),
     EVENTID ("org.labkey.snd.api.Event", 2000000),
-    EVENTDATAID ("org.labkey.snd.api.EventData", 3000000);
+    EVENTDATAID ("org.labkey.snd.api.EventData", 3500000);
 
     private String sequenceName;
     private int minId;


### PR DESCRIPTION
#### Rationale
The Current value of the EventDataId in CAMP is now at 3.2 million+. 

