### PR TITLE
Code changes for JsonObject Note element Not Mandatory

### DIFF
--- a/src/org/labkey/snd/SNDController.java
+++ b/src/org/labkey/snd/SNDController.java
@@ -1006,7 +1006,7 @@ public class SNDController extends SpringActionController
             if (!errors.hasErrors())
             {
                 String projectIdrev = json.getString("projectIdRev");
-                String note = json.getString("note");
+                String note = json.has("note") ? json.getString("note") : null;
 
                 List<EventData> eventData = null;
                 JSONArray eventDataJson = json.has("eventData") ? json.getJSONArray("eventData") : null;


### PR DESCRIPTION
Added code to check for note element availability in the JsonObject. if not available setting it to null

