### PR TITLE
Issue 48499: Use preferred SecurityPolicyManager.savePolicy() variant

### DIFF
--- a/api-src/org/labkey/api/snd/Category.java
+++ b/api-src/org/labkey/api/snd/Category.java
@@ -25,6 +25,7 @@ import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.User;
 import org.labkey.api.util.GUID;
 
+import java.util.Collections;
 import java.util.List;
 
 public class Category implements SecurableResource, HasPermission
@@ -124,7 +125,7 @@ public class Category implements SecurableResource, HasPermission
     @Override
     public @NotNull List<SecurableResource> getChildResources(User user)
     {
-        return null;
+        return Collections.emptyList();
     }
 
     @Override

--- a/src/org/labkey/snd/SNDController.java
+++ b/src/org/labkey/snd/SNDController.java
@@ -1284,7 +1284,7 @@ public class SNDController extends SpringActionController
         public Object execute(SimpleApiJsonForm form, BindException errors)
         {
             JSONObject json = form.getJsonObject();
-            Integer categoryId = json.getInt("categoryId");
+            int categoryId = json.getInt("categoryId");
             String groupName = json.getString("groupName");
             String roleName = json.getString("roleName");
 

--- a/src/org/labkey/snd/SNDServiceImpl.java
+++ b/src/org/labkey/snd/SNDServiceImpl.java
@@ -24,6 +24,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
@@ -80,6 +81,7 @@ public class SNDServiceImpl implements SNDService
 
     private SNDServiceImpl()
     {
+        ContainerManager.addSecurableResourceProvider((c, u) -> getAllCategories(c, u).values());
     }
 
     private static void configureObjectMapper(ObjectMapper om)

--- a/src/org/labkey/snd/security/SNDSecurityManager.java
+++ b/src/org/labkey/snd/security/SNDSecurityManager.java
@@ -70,7 +70,7 @@ public class SNDSecurityManager
 
         List<Category> categories = SNDManager.get().getCategories(c, u, categoryIds);
         Category category;
-        if (categories != null && categories.size() > 0)
+        if (categories != null && !categories.isEmpty())
         {
             category = categories.get(0);
             Group group = SecurityManager.getGroup(SecurityManager.getGroupId(c, groupName));
@@ -95,20 +95,14 @@ public class SNDSecurityManager
                 }
 
                 // Clear role first
-                if (role != null || roleName.equals("None"))
-                {
-                    policy.clearAssignedRoles(group);
-                }
+                policy.clearAssignedRoles(group);
 
                 if (role != null)
                 {
                     policy.addRoleAssignment(group, role);
                 }
 
-                if (role != null || roleName.equals("None"))
-                {
-                    SecurityPolicyManager.savePolicy(policy);
-                }
+                SecurityPolicyManager.savePolicy(policy, u);
             }
             else
             {
@@ -194,7 +188,7 @@ public class SNDSecurityManager
         // save all policies
         for (MutableSecurityPolicy savedPolicy : policyMap.values())
         {
-            SecurityPolicyManager.savePolicy(savedPolicy);
+            SecurityPolicyManager.savePolicy(savedPolicy, u);
         }
     }
 


### PR DESCRIPTION
#### Rationale
We're uneven in terms of the validation and auditing we do for saving SecurityPolicies and related updates, and want to be more consistent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4704

#### Changes
* Let modules register ContainerSecurableResourceProviders instead of having Container know about them all
* Remove the `savePolicy` and `createContainer` methods that don't take a user, check permissions, or log for audit purposes
* Introduce `User.getAdminServiceUser()` for `sudo` like scenarios or when we're doing an operation not initiated by a user, like bootstrapping the server
* Update callers