### PR TITLE
Extend Basic Submitter capabilities

### DIFF
--- a/src/org/labkey/snd/security/roles/SNDBasicSubmitterRole.java
+++ b/src/org/labkey/snd/security/roles/SNDBasicSubmitterRole.java
@@ -21,6 +21,10 @@ import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.roles.AbstractModuleScopedRole;
 import org.labkey.api.snd.Category;
 import org.labkey.snd.SNDModule;
+import org.labkey.snd.security.permissions.SNDCompletedDeletePermission;
+import org.labkey.snd.security.permissions.SNDCompletedInsertPermission;
+import org.labkey.snd.security.permissions.SNDCompletedReadPermission;
+import org.labkey.snd.security.permissions.SNDCompletedUpdatePermission;
 import org.labkey.snd.security.permissions.SNDInProgressDeletePermission;
 import org.labkey.snd.security.permissions.SNDInProgressInsertPermission;
 import org.labkey.snd.security.permissions.SNDInProgressReadPermission;
@@ -42,7 +46,11 @@ public class SNDBasicSubmitterRole extends AbstractModuleScopedRole
                 SNDInProgressUpdatePermission.class, SNDInProgressDeletePermission.class,
                 SNDReviewRequiredReadPermission.class, SNDReviewRequiredInsertPermission.class,
                 SNDReviewRequiredUpdatePermission.class, SNDReviewRequiredDeletePermission.class,
-                SNDRejectedReadPermission.class, SNDRejectedDeletePermission.class);
+                SNDRejectedReadPermission.class, SNDRejectedDeletePermission.class,
+                // allow basic submitters to read, update, insert, and delete completed data
+                // This is needed uptil SNPRC releases the new QC workflow
+                SNDCompletedInsertPermission.class, SNDCompletedDeletePermission.class,
+                SNDCompletedReadPermission.class, SNDCompletedUpdatePermission.class);
     }
 
     @Override

--- a/webapp/snd/test/tests.js
+++ b/webapp/snd/test/tests.js
@@ -592,25 +592,25 @@
                 }
             }
         },
-        /*{
-            // This test is commented out because it is not currently valid:
-            // allow basic submitters to read, update, insert, and delete completed data
-            // This is needed uptil SNPRC releases the new QC workflow
-            name: 'Get Event: Invalid permission. Basic submitter reading completed data.',
-            roles: ['org.labkey.api.security.roles.ReaderRole',
-                'org.labkey.api.security.roles.EditorRole',
-                'org.labkey.snd.security.roles.SNDBasicSubmitterRole'],
-            run : function()
-            {
-                return{
-                    request:{
-                        url:LABKEY.SND_TEST_URLS.GET_EVENT_URL,
-                        jsonData:{"eventId": "1800002"}
-                    },
-                    expectedFailure : 'You do not have permission to Read event data for QC state Completed for these super packages.'
-                }
-            }
-        }, */
+        //{
+        //     // This test is commented out because it is not currently valid:
+        //     // allow basic submitters to read, update, insert, and delete completed data
+        //     // This is needed uptil SNPRC releases the new QC workflow
+        //     name: 'Get Event: Invalid permission. Basic submitter reading completed data.',
+        //     roles: ['org.labkey.api.security.roles.ReaderRole',
+        //         'org.labkey.api.security.roles.EditorRole',
+        //         'org.labkey.snd.security.roles.SNDBasicSubmitterRole'],
+        //     run : function()
+        //     {
+        //         return{
+        //             request:{
+        //                 url:LABKEY.SND_TEST_URLS.GET_EVENT_URL,
+        //                 jsonData:{"eventId": "1800002"}
+        //             },
+        //             expectedFailure : 'You do not have permission to Read event data for QC state Completed for these super packages.'
+        //         }
+        //     }
+        // },
         {
             name: 'Get Event: Valid permission. Data reviewer reading completed data.',
             roles: ['org.labkey.api.security.roles.ReaderRole',

--- a/webapp/snd/test/tests.js
+++ b/webapp/snd/test/tests.js
@@ -660,29 +660,34 @@
                     }
                 }
             }
-        }, {
-
-            name: 'Delete Event: Invalid permission. Basic submitter role cannot delete completed data.',
-            roles: ['org.labkey.api.security.roles.ReaderRole',
-                'org.labkey.api.security.roles.EditorRole',
-                'org.labkey.snd.security.roles.SNDBasicSubmitterRole'],
-            run : function()
-            {
-                return{
-                    request:{
-                        url:LABKEY.SND_TEST_URLS.DELETE_EVENT_URL,
-                        jsonData: {
-                            schemaName: 'snd',
-                            queryName: 'Events',
-                            rows: [{
-                                EventId: 1800002
-                            }]
-                        }
-                    },
-                    expectedFailure : 'You do not have permission to Delete event data for QC state Completed for these super packages.'
-                }
-            }
-        },{
+        },
+        //     // This test is commented out because it is not currently valid:
+        //     // allow basic submitters to read, update, insert, and delete completed data
+        //     // This is needed uptil SNPRC releases the new QC workflow
+        // {
+        //
+        //     name: 'Delete Event: Invalid permission. Basic submitter role cannot delete completed data.',
+        //     roles: ['org.labkey.api.security.roles.ReaderRole',
+        //         'org.labkey.api.security.roles.EditorRole',
+        //         'org.labkey.snd.security.roles.SNDBasicSubmitterRole'],
+        //     run : function()
+        //     {
+        //         return{
+        //             request:{
+        //                 url:LABKEY.SND_TEST_URLS.DELETE_EVENT_URL,
+        //                 jsonData: {
+        //                     schemaName: 'snd',
+        //                     queryName: 'Events',
+        //                     rows: [{
+        //                         EventId: 1800002
+        //                     }]
+        //                 }
+        //             },
+        //             expectedFailure : 'You do not have permission to Delete event data for QC state Completed for these super packages.'
+        //         }
+        //     }
+        // },
+        {
 
             name: 'Delete Event: Correct permission. Data admin role.',
             roles: ['org.labkey.api.security.roles.ReaderRole',

--- a/webapp/snd/test/tests.js
+++ b/webapp/snd/test/tests.js
@@ -591,8 +591,11 @@
                     }
                 }
             }
-        },{
-
+        },
+        /*{
+            // This test is commented out because it is not currently valid:
+            // allow basic submitters to read, update, insert, and delete completed data
+            // This is needed uptil SNPRC releases the new QC workflow
             name: 'Get Event: Invalid permission. Basic submitter reading completed data.',
             roles: ['org.labkey.api.security.roles.ReaderRole',
                 'org.labkey.api.security.roles.EditorRole',
@@ -607,8 +610,8 @@
                     expectedFailure : 'You do not have permission to Read event data for QC state Completed for these super packages.'
                 }
             }
-        },{
-
+        }, */
+        {
             name: 'Get Event: Valid permission. Data reviewer reading completed data.',
             roles: ['org.labkey.api.security.roles.ReaderRole',
                 'org.labkey.api.security.roles.EditorRole',


### PR DESCRIPTION
#### Rationale
Until SNPRC implements the QC workflow, the basic submitter roll needs to be able to submit data in the Completed QC State.

#### Changes
Allow basic submitters to read, update, insert, and delete completed data
