### PR TITLE
Remove deprecated ContainerFilter.getSQLFragment

### DIFF
--- a/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/src/org/labkey/snd/query/AttributeDataTable.java
@@ -118,7 +118,7 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
         sql.append(OntologyManager.getTinfoObject(), "o");
         sql.append(" ON x.ObjectId = o.ObjectId AND ");
         // Apply the container filter
-        sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("o.Container"), getContainer()));
+        sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("o.Container")));
         sql.append(" INNER JOIN ");
         sql.append(OntologyManager.getTinfoPropertyDescriptor(), "pd");
         // Filter to include only properties associated with packages


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/5073 for rationale.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5073

#### Changes
* Remove `ContainerFilter.getSQLFragment(DbSchema, SQLFragment, Container)` and replace usages with calls to `ContainerFilter.getSQLFragment(DbSchema, SQLFragment)`.
