### PR TITLE
Modified SNDManager-getProjectItemsList query to return package Narratives along with other Package Details 

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -3344,7 +3344,7 @@ public class SNDManager
     {
         UserSchema schema = getSndUserSchema(c, u);
 
-        SQLFragment sql = new SQLFragment("SELECT pi.ProjectItemId, pi.superPkgId, p.pkgId, p.description, p.modified FROM ");
+        SQLFragment sql = new SQLFragment("SELECT pi.ProjectItemId, pi.superPkgId, p.pkgId, p.description, p.modified, p.narrative FROM ");
         sql.append(schema.getTable(SNDSchema.PROJECTITEMS_TABLE_NAME, null, true, false), "pi");
         sql.append(" JOIN ");
         sql.append(schema.getTable(SNDSchema.PROJECTS_TABLE_NAME, null, true, false), "pr");


### PR DESCRIPTION
Made Code Changes for Widget Narrative Population using the api call - getActiveProjects. The narratives are not populated in the response of this call. So made changes in the SNDManager class getProjectItemsList query method to return the package Narratives as part of the api response.

