### PR TITLE
Missing property descriptor for attribute exception handling

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -2300,14 +2300,13 @@ public class SNDManager
 
         for (AttributeData attributeData : eventData.getAttributes())
         {
-            if (attributeData.getPropertyName() != null)
+            propertyDescriptor = OntologyManager.getPropertyDescriptor(attributeData.getPropertyId());
+
+            if (propertyDescriptor == null)
             {
-                propertyDescriptor = OntologyManager.getPropertyDescriptor(PackageDomainKind.getDomainURI(
-                        SNDSchema.NAME, PackageDomainKind.getPackageKindName(), c, u) + "-" + pkgId + "#" + attributeData.getPropertyName(), c);
-            }
-            else
-            {
-                propertyDescriptor = OntologyManager.getPropertyDescriptor(attributeData.getPropertyId());
+               propertyDescriptor = OntologyManager.getPropertyDescriptor(PackageDomainKind.getDomainURI(
+                        SNDSchema.NAME, PackageDomainKind.getPackageKindName(), c, u) + "-" + pkgId + "#" +
+                        attributeData.getPropertyName().replaceAll("\\s", "+"), c);
             }
 
             if (propertyDescriptor != null)

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -2327,6 +2327,11 @@ public class SNDManager
                     OntologyManager.insertProperties(c, u, null, objectProperty);
                 }
             }
+            else
+            {
+                // property descriptor not found
+                throw new ValidationException("Property descriptor not found for attribute: " + attributeData.getPropertyName());
+            }
         }
 
         return objectURI;


### PR DESCRIPTION
#### Rationale
We need to roll back the SaveEvent transaction when an SND attribute cannot be updated because the PD has an invalid name. 

MDP-88:  SNPRC_Mobile - Fix SND saveEvent API failure to report error when propertyDescriptor is not found for AttributeData

