### PR TITLE
Should use LabKey helper methods to encode propertyURI parts

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -2306,7 +2306,7 @@ public class SNDManager
             {
                propertyDescriptor = OntologyManager.getPropertyDescriptor(PackageDomainKind.getDomainURI(
                         SNDSchema.NAME, PackageDomainKind.getPackageKindName(), c, u) + "-" + pkgId + "#" +
-                        attributeData.getPropertyName().replaceAll("\\s", "+"), c);
+                        Lsid.encodePart(attributeData.getPropertyName()), c);
             }
 
             if (propertyDescriptor != null)


### PR DESCRIPTION
Used Lsid encoding method to ensure propertyURIs match values in the database.