### PR TITLE
Optimize getEvent methods to decrease query time

### DIFF
--- a/api-src/org/labkey/api/snd/EventData.java
+++ b/api-src/org/labkey/api/snd/EventData.java
@@ -40,7 +40,6 @@ public class EventData
 {
     private Integer _eventDataId;
     private int _superPkgId;
-    private int _pkgId;
     private int _eventId;
     private Integer _parentEventDataId;
     private Integer _sortOrder;

--- a/api-src/org/labkey/api/snd/EventData.java
+++ b/api-src/org/labkey/api/snd/EventData.java
@@ -40,6 +40,7 @@ public class EventData
 {
     private Integer _eventDataId;
     private int _superPkgId;
+    private int _pkgId;
     private int _eventId;
     private Integer _parentEventDataId;
     private Integer _sortOrder;

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -2814,9 +2814,7 @@ public class SNDManager
                                 QueryUpdateService eventQus = getQueryUpdateService(eventTable);
                                 QueryUpdateService eventsCacheQus = getNewQueryUpdateService(schema, SNDSchema.EVENTSCACHE_TABLE_NAME);
 
-                                String htmlEventNarrative = generateEventNarrative(c, u, event, topLevelEventDataPkgs, true, false);
-                                Map<String, Object> eventsCacheRow = getEventsCacheRow(c, u, event.getEventId(), htmlEventNarrative);
-                                String textEventNarrative = PlainTextNarrativeDisplayColumn.removeHtmlTagsFromNarrative(htmlEventNarrative);
+
                                 BatchValidationException errors = new BatchValidationException();
 
                                 QueryUpdateService eventNotesQus = null;
@@ -2836,8 +2834,10 @@ public class SNDManager
                                     }
 
                                     insertEventDatas(c, u, event, errors);
+                                    String htmlEventNarrative = generateEventNarrative(c, u, event, topLevelEventDataPkgs, true, false);
+                                    Map<String, Object> eventsCacheRow = getEventsCacheRow(c, u, event.getEventId(), htmlEventNarrative);
+                                    String textEventNarrative = PlainTextNarrativeDisplayColumn.removeHtmlTagsFromNarrative(htmlEventNarrative);
                                     eventsCacheQus.insertRows(u, c, Collections.singletonList(eventsCacheRow), errors, null, null);
-                                    generateEventNarrative(c, u, event, topLevelEventDataPkgs, true, false);
                                     NarrativeAuditProvider.addAuditEntry(c, u, event.getEventId(), event.getSubjectId(), event.getDate(), textEventNarrative, event.getQcState(), "Create event");
                                     tx.commit();
                                 }
@@ -3425,10 +3425,12 @@ public class SNDManager
                 tabIndex++;
                 for (EventData data : eventData.getSubPackages())
                 {
-                    if (data.getEventDataId() != null) {
+                    if (data.getEventDataId() != null)
+                    {
                         eventDataNarrative.append(generateEventDataNarrative(c, u, event, data,
                                 getSuperPackage(data.getSuperPkgId(), superPackage.getChildPackages()), tabIndex, genHtml, genRedacted));
                     }
+
                 }
             }
         }
@@ -3476,11 +3478,8 @@ public class SNDManager
         {
             for (EventData eventData : event.getEventData())
             {
-                if (eventData.getEventDataId() != null)
-                {
-                    narrative.append(generateEventDataNarrative(c, u, event, eventData,
-                            topLevelEventDataSuperPkgs.get(eventData.getEventDataId()), 0, genHtml, genRedacted));
-                }
+                narrative.append(generateEventDataNarrative(c, u, event, eventData,
+                        topLevelEventDataSuperPkgs.get(eventData.getEventDataId()), 0, genHtml, genRedacted));
             }
         }
 

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -3985,6 +3985,7 @@ public class SNDManager
                 if (subEventData != null) {
                     List<EventData> sorted = subEventData.get(eventData.getEventId()).stream().sorted(Comparator.comparing(
                                     (EventData child) -> nextLevelSuperPkgs.get(child.getEventId()).get(child.getEventDataId()).getTreePath()))
+                            .filter(ed -> ed.getParentEventDataId() == null || ed.getParentEventDataId().equals(eventData.getEventDataId()))
                             .collect(Collectors.toList());
                     eventData.setSubPackages(sorted);
                 }

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -3707,7 +3707,7 @@ public class SNDManager
     private Map<Integer, Map<Integer, SuperPackage>> getBulkTopLevelEventDataSuperPkgs(Container c, User u, List<Integer> eventIds, Map<Integer, SuperPackage> superPackages) {
 
         // EventData from query - SELECT * FROM EventData WHERE EventId IN {eventIds} AND ParentEventId IS NULL ORDER BY EventDataId
-        TableSelector eventDataSelector = getTableSelector(c, u, eventIds, SNDSchema.EVENTDATA_TABLE_NAME, "EventId", "EventDataId", "ParentEventDataId");
+        TableSelector eventDataSelector = getTableSelector(c, u, eventIds, SNDSchema.EVENTDATA_TABLE_NAME, Event.EVENT_ID, EventData.EVENT_DATA_ID, EventData.EVENT_DATA_PARENT_EVENTDATAID);
         List<EventData> allEventData = eventDataSelector.getArrayList(EventData.class);
 
         // Get SuperPackages for eventData and group by EventId
@@ -3779,11 +3779,11 @@ public class SNDManager
                                             List<GWTPropertyDescriptor> eventExtraFields, List<GWTPropertyDescriptor> eventDataExtraFields) {
 
         // Events from query - SELECT * FROM Events WHERE EventId IN {eventIds}
-        TableSelector eventSelector = getTableSelector(c, u, eventIds, SNDSchema.EVENTS_TABLE_NAME, "EventId", null, null);
+        TableSelector eventSelector = getTableSelector(c, u, eventIds, SNDSchema.EVENTS_TABLE_NAME, Event.EVENT_ID, null, null);
         List<Event> events = eventSelector.getArrayList(Event.class);
         Collection<Map<String, Object>> eventsExtensibleFields = eventSelector.getMapCollection();
 
-        TableSelector eventDataSelector = getTableSelector(c, u, eventIds, SNDSchema.EVENTDATA_TABLE_NAME, "EventId", null, null);
+        TableSelector eventDataSelector = getTableSelector(c, u, eventIds, SNDSchema.EVENTDATA_TABLE_NAME, Event.EVENT_ID, null, null);
         List<EventData> rawEventData = eventDataSelector.getArrayList(EventData.class);
         Collection<Map<String, Object>> eventDataExtensibleFields = eventDataSelector.getMapCollection();
 
@@ -3803,7 +3803,7 @@ public class SNDManager
 
             Map<String, Object> extraFields = eventsExtensibleFields
                     .stream()
-                    .filter((Map<String, Object> map) -> event.getEventId().equals(map.get("eventId")))
+                    .filter((Map<String, Object> map) -> event.getEventId().equals(map.get(Event.EVENT_ID)))
                     .findFirst()
                     .orElse(Collections.emptyMap());
 
@@ -4016,7 +4016,7 @@ public class SNDManager
 
             Map<String, Object> extraFields = eventDataExtensibleFields
                     .stream()
-                    .filter((Map<String, Object> map) -> eventData.getEventDataId().equals(map.get("eventDataId")))
+                    .filter((Map<String, Object> map) -> eventData.getEventDataId().equals(map.get(EventData.EVENT_DATA_ID)))
                     .findFirst()
                     .orElse(Collections.emptyMap());
 
@@ -4149,7 +4149,7 @@ public class SNDManager
     private Map<Integer, String> getBulkEventNotes(Container c, User u, List<Integer> eventIds) {
 
         // EventNotes from query - SELECT * FROM EventNotes WHERE EventId IN {eventIds}
-        TableSelector eventNoteSelector = getTableSelector(c, u, eventIds, SNDSchema.EVENTNOTES_TABLE_NAME, "EventId", null, null);
+        TableSelector eventNoteSelector = getTableSelector(c, u, eventIds, SNDSchema.EVENTNOTES_TABLE_NAME, Event.EVENT_ID, null, null);
         List<EventNote> eventNotes = eventNoteSelector.getArrayList(EventNote.class);
 
         // Group eventNotes by eventId
@@ -4173,7 +4173,7 @@ public class SNDManager
     private Map<String, String> getBulkProjectIdRevs(Container c, User u, List<String> objectIds) {
 
         // Projects from query - SELECT * FROM Projects WHERE ObjectId IN {objectIds}
-        TableSelector projectSelector = getTableSelector(c, u, objectIds, SNDSchema.PROJECTS_TABLE_NAME, "ObjectId", null, null);
+        TableSelector projectSelector = getTableSelector(c, u, objectIds, SNDSchema.PROJECTS_TABLE_NAME, Project.PROJECT_OBJECTID, null, null);
         List<Project> projects = projectSelector.getArrayList(Project.class);
 
         // Concat string of ProjectId + RevisionNum and Group by ObjectId

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -3663,6 +3663,7 @@ public class SNDManager
 
     /**
      * Query the EventData table and create a Map of all top level SuperPackages for a set of eventIds
+     *
      * @param c
      * @param u
      * @param eventIds
@@ -3724,6 +3725,7 @@ public class SNDManager
 
     /**
      * Query the Event table and retrieve rows for a set of eventIds and populate data/create narratives
+     *
      * @param c
      * @param u
      * @param eventIds
@@ -3795,7 +3797,6 @@ public class SNDManager
 
         return eventsById;
     }
-
 
     /**
      * Return a cached map of SuperPackage objects by superPkgId
@@ -3880,9 +3881,9 @@ public class SNDManager
         });
 
         return superPackagesById;
+
     }
-
-
+    
     /**
      * Retrieve the child SuperPackage objects for a list of SuperPackages
      * @param c

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -1142,10 +1142,11 @@ public class SNDManager
      * Gets a list of full packages given a list of package Ids. Options to include extensible columns, lookup values and
      * all attributes for sub packages.
      */
-    public List<Package> getPackages(Container c, User u, List<Integer> pkgIds,  boolean includeExtraFields, boolean includeLookups,
+    public List<Package> getPackages(Container c, User u, List<Integer> pkgIds, boolean includeExtraFields, boolean includeLookups,
                                      boolean includeFullSubpackages, BatchValidationException errors)
     {
         UserSchema schema = getSndUserSchema(c, u);
+
         TableInfo pkgsTable = getTableInfo(schema, SNDSchema.PKGS_TABLE_NAME);
         QueryUpdateService pkgQus = getQueryUpdateService(pkgsTable);
 
@@ -3855,7 +3856,7 @@ public class SNDManager
         } else {
             pkgCategoriesByPkgId = new HashMap<>();
         }
-        
+
         Map<Integer, List<SuperPackage>> childrenByParentId = fullTreeSuperPkgs.stream().filter(sp -> sp.getParentSuperPkgId() != null).collect(Collectors.groupingBy(SuperPackage::getParentSuperPkgId));
 
         Map<Integer, SuperPackage> superPackagesById = superPackages.stream().collect(Collectors.toMap(

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -3425,8 +3425,10 @@ public class SNDManager
                 tabIndex++;
                 for (EventData data : eventData.getSubPackages())
                 {
-                    eventDataNarrative.append(generateEventDataNarrative(c, u, event, data,
-                            getSuperPackage(data.getSuperPkgId(), superPackage.getChildPackages()), tabIndex, genHtml, genRedacted));
+                    if (data.getEventDataId() != null) {
+                        eventDataNarrative.append(generateEventDataNarrative(c, u, event, data,
+                                getSuperPackage(data.getSuperPkgId(), superPackage.getChildPackages()), tabIndex, genHtml, genRedacted));
+                    }
                 }
             }
         }
@@ -3474,8 +3476,11 @@ public class SNDManager
         {
             for (EventData eventData : event.getEventData())
             {
-                narrative.append(generateEventDataNarrative(c, u, event, eventData,
-                        topLevelEventDataSuperPkgs.get(eventData.getEventDataId()), 0, genHtml, genRedacted));
+                if (eventData.getEventDataId() != null)
+                {
+                    narrative.append(generateEventDataNarrative(c, u, event, eventData,
+                            topLevelEventDataSuperPkgs.get(eventData.getEventDataId()), 0, genHtml, genRedacted));
+                }
             }
         }
 

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -92,6 +92,7 @@ import org.labkey.snd.trigger.SNDTriggerManager;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -101,9 +102,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.labkey.api.snd.EventNarrativeOption.HTML_NARRATIVE;
@@ -565,6 +570,51 @@ public class SNDManager
     }
 
     /**
+     * Gets the category ids for a list of pkgIds
+     */
+    private Map<Integer, Map<Integer, String>> getAllPackageCategories(Container c, User u, @Nullable List<Integer> pkgIds, BatchValidationException errors)
+    {
+        UserSchema schema = getSndUserSchema(c, u);
+
+        SQLFragment sql = new SQLFragment("SELECT cj.CategoryId, ca.Description, PkgId FROM ");
+        sql.append(schema.getTable(SNDSchema.PKGCATEGORYJUNCTION_TABLE_NAME), "cj");
+        sql.append(" JOIN ");
+        sql.append(schema.getTable(SNDSchema.PKGCATEGORIES__TABLE_NAME), "ca");
+        sql.append(" ON cj.CategoryId = ca.CategoryId");
+        if (pkgIds != null) {
+            sql.append(" WHERE PkgId IN ( ");
+            ArrayDeque<Integer> pkgIdsQueue = new ArrayDeque<>(pkgIds);
+            while (pkgIdsQueue.size() > 1) {
+                sql.append("?, ").add(pkgIdsQueue.pop());
+            }
+            sql.append("?) ").add(pkgIdsQueue.pop());
+        }
+        SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
+
+        Map<Integer, Map<Integer, String>> pkgCategoriesByPkgId = new HashMap<>();
+
+        try (TableResultSet rs = selector.getResultSet())
+        {
+            for (Map<String, Object> r : rs)
+            {
+                Integer pkgId = (Integer) r.get("PkgId");
+                Integer categoryId = (Integer) r.get("CategoryId");
+                String description = (String) r.get ("Description");
+                if (!pkgCategoriesByPkgId.containsKey(pkgId)) {
+                    pkgCategoriesByPkgId.put(pkgId, new HashMap<>());
+                }
+                pkgCategoriesByPkgId.get(pkgId).put(categoryId, description);
+            }
+        }
+        catch (SQLException e)
+        {
+            errors.addRowError(new ValidationException(e.getMessage()));
+        }
+
+        return pkgCategoriesByPkgId;
+    }
+
+    /**
      * Gets the extensible fields for a given table
      */
     public static List<GWTPropertyDescriptor> getExtraFields(Container c, User u, String tableName)
@@ -583,6 +633,28 @@ public class SNDManager
     public Package addExtraFieldsToPackage(Container c, User u, Package pkg, @Nullable Map<String, Object> row)
     {
         List<GWTPropertyDescriptor> extraFields = SNDManager.getExtraFields(c, u, SNDSchema.PKGS_TABLE_NAME);
+        Map<GWTPropertyDescriptor, Object> extras = new HashMap<>();
+        for (GWTPropertyDescriptor extraField : extraFields)
+        {
+            if (row == null)
+            {
+                extras.put(extraField, "");
+            }
+            else
+            {
+                extras.put(extraField, row.get(extraField.getName()));
+            }
+        }
+        pkg.setExtraFields(extras);
+
+        return pkg;
+    }
+
+    /**
+     * Add extensible fields to the package object when getting the package for an API
+     */
+    public Package addExtraFieldsToPackage(Package pkg, List<GWTPropertyDescriptor> extraFields, @Nullable Map<String, Object> row)
+    {
         Map<GWTPropertyDescriptor, Object> extras = new HashMap<>();
         for (GWTPropertyDescriptor extraField : extraFields)
         {
@@ -853,6 +925,9 @@ public class SNDManager
     {
         UserSchema schema = getSndUserSchema(c, u);
 
+        TableInfo pkgsTable = getTableInfo(schema, SNDSchema.PKGS_TABLE_NAME);
+        QueryUpdateService pkgQus = getQueryUpdateService(pkgsTable);
+
         SQLFragment sql = new SQLFragment("SELECT sp.SuperPkgId, sp.PkgId, sp.SortOrder, sp.Required, pkg.PkgId, pkg.Description, pkg.Active, pkg.Narrative, pkg.Repeatable FROM ");
         sql.append(schema.getTable(SNDSchema.SUPERPKGS_TABLE_NAME), "sp");
         sql.append(" JOIN " + SNDSchema.NAME + "." + SNDSchema.PKGS_TABLE_NAME + " pkg");
@@ -998,14 +1073,98 @@ public class SNDManager
     }
 
     /**
+     * Given a row from the snd.Pkgs table, this creates the Package object.  Options to include extensible columns, lookup values
+     * and attributes of subpackages
+     */
+    private Package getFullPackage(Container c, User u, Map<String, Object> row, List<GWTPropertyDescriptor> packageExtraFields,
+                                 List<SuperPackage> superPackages, Map<Integer, List<SuperPackage>> childrenByParentId,
+                                   Map<Integer, Map<Integer, String>> pkgCategoriesByPkgId, boolean includeExtraFields,
+                                  boolean includeLookups, boolean includeFullSubpackages, BatchValidationException errors)
+    {
+        Package pkg = new Package();
+        if (row != null)
+        {
+            pkg.setPkgId((Integer) row.get(Package.PKG_ID));
+            pkg.setDescription((String) row.get(Package.PKG_DESCRIPTION));
+            pkg.setActive((boolean) row.get(Package.PKG_ACTIVE));
+            pkg.setRepeatable((boolean) row.get(Package.PKG_REPEATABLE));
+            pkg.setNarrative((String) row.get(Package.PKG_NARRATIVE));
+            pkg.setQcState((Integer) row.get(Package.PKG_QCSTATE));
+            pkg.setHasEvent((boolean) row.get(Package.PKG_HASEVENT));
+            pkg.setHasProject((boolean) row.get(Package.PKG_HASPROJECT));
+            pkg.setModified((Date) row.get(Package.PKG_MODIFIED));
+            pkg.setCategories(pkgCategoriesByPkgId.get(pkg.getPkgId()));
+            pkg.setAttributes(getPackageAttributes(c, u, pkg.getPkgId()));
+
+            Optional<SuperPackage> topLevelSuperPkg = superPackages.stream().filter(s -> s.getPkgId().equals(pkg.getPkgId()) && s.getParentSuperPkgId() == null)
+                    .findFirst();
+
+            topLevelSuperPkg.ifPresent(superPackage -> pkg.setTopLevelSuperPkgId(superPackage.getSuperPkgId()));
+
+            if(includeFullSubpackages) {
+                Integer superPkgId = superPackages.stream().filter(s -> s.getPkgId().equals(pkg.getPkgId()))
+                        .findFirst().get().getSuperPkgId();
+                List<SuperPackage> subPackages = childrenByParentId.getOrDefault(superPkgId, new ArrayList<>());
+                pkg.setSubpackages(subPackages);
+            }
+
+            if (includeExtraFields)
+                addExtraFieldsToPackage(pkg, packageExtraFields, row);
+            if (includeLookups)
+                addLookupsToPkg(c, u, pkg);
+        }
+
+        return pkg;
+    }
+    /**
      * Gets a list of full packages given a list of package Ids. Options to include extensible columns, lookup values and
      * all attributes for sub packages.
      */
-    public List<Package> getPackages(Container c, User u, List<Integer> pkgIds, boolean includeExtraFields, boolean includeLookups,
+    public List<Package> getFullPackages(Container c, User u, List<Integer> pkgIds, QueryUpdateService pkgQus,
+                                     List<GWTPropertyDescriptor> packageExtraFields, List<SuperPackage> superPackages,
+                                         Map<Integer, List<SuperPackage>> childrenByParentId,
+                                         Map<Integer, Map<Integer, String>> pkgCategoriesByPkgId,
+                                     boolean includeExtraFields, boolean includeLookups, boolean includeFullSubpackages, BatchValidationException errors)
+    {
+        List<Map<String, Object>> rows = null;
+        List<Map<String, Object>> keys = new ArrayList<>();
+        Map<String, Object> key;
+        for (Integer pkgId : pkgIds)
+        {
+            key = new HashMap<>();
+            key.put("PkgId", pkgId);
+            keys.add(key);
+        }
+
+        List<Package> packages = new ArrayList<>();
+        try
+        {
+            rows = pkgQus.getRows(u, c, keys);
+        }
+        catch (InvalidKeyException | QueryUpdateServiceException | SQLException e)
+        {
+            errors.addRowError(new ValidationException(e.getMessage()));
+        }
+
+        if (!errors.hasErrors() && rows != null && !rows.isEmpty())
+        {
+            for (Map<String, Object> row : rows)
+            {
+                packages.add(getFullPackage(c, u, row, packageExtraFields, superPackages, childrenByParentId, pkgCategoriesByPkgId, includeExtraFields, includeLookups, includeFullSubpackages, errors));
+            }
+        }
+
+        return packages;
+    }
+
+    /**
+     * Gets a list of full packages given a list of package Ids. Options to include extensible columns, lookup values and
+     * all attributes for sub packages.
+     */
+    public List<Package> getPackages(Container c, User u, List<Integer> pkgIds,  boolean includeExtraFields, boolean includeLookups,
                                      boolean includeFullSubpackages, BatchValidationException errors)
     {
         UserSchema schema = getSndUserSchema(c, u);
-
         TableInfo pkgsTable = getTableInfo(schema, SNDSchema.PKGS_TABLE_NAME);
         QueryUpdateService pkgQus = getQueryUpdateService(pkgsTable);
 
@@ -2919,8 +3078,12 @@ public class SNDManager
         UserSchema sndSchema = getSndUserSchemaAdminRole(c, u);
         QueryUpdateService eventsCacheQus = getNewQueryUpdateService(sndSchema, SNDSchema.EVENTSCACHE_TABLE_NAME);
 
+        TableInfo pkgsTable = getTableInfo(sndSchema, SNDSchema.PKGS_TABLE_NAME);
+        QueryUpdateService pkgQus = getQueryUpdateService(pkgsTable);
+
         List<GWTPropertyDescriptor> eventExtraFields = getExtraFields(c, u, SNDSchema.EVENTS_TABLE_NAME);
         List<GWTPropertyDescriptor> eventDataExtraFields = getExtraFields(c, u, SNDSchema.EVENTDATA_TABLE_NAME);
+        List<GWTPropertyDescriptor> packageExtraFields = getExtraFields(c, u, SNDSchema.PKGS_TABLE_NAME);
 
         // Logger for pipeline
         if (logger != null)
@@ -2928,7 +3091,7 @@ public class SNDManager
             logger.info("Generating narratives.");
         }
 
-        Map<Integer, SuperPackage> superPackages = getAllFullSuperPackages(c, u, errors);
+        Map<Integer, SuperPackage> superPackages = getAllFullSuperPkgs(c, u, packageExtraFields, pkgQus, null, errors);
 
         AtomicInteger count = new AtomicInteger(0);
 
@@ -3492,6 +3655,28 @@ public class SNDManager
 
     }
 
+    @Nullable
+    public Event getEvent(Container c, User u, int eventId, Set<EventNarrativeOption> narrativeOptions, boolean skipPermissionCheck, BatchValidationException errors) {
+
+        UserSchema schema = getSndUserSchema(c, u);
+
+        TableInfo pkgsTable = getTableInfo(schema, SNDSchema.PKGS_TABLE_NAME);
+        QueryUpdateService pkgQus = getQueryUpdateService(pkgsTable);
+
+        List<GWTPropertyDescriptor> eventExtraFields = getExtraFields(c, u, SNDSchema.EVENTS_TABLE_NAME);
+        List<GWTPropertyDescriptor> eventDataExtraFields = getExtraFields(c, u, SNDSchema.EVENTDATA_TABLE_NAME);
+        List<GWTPropertyDescriptor> packageExtraFields = getExtraFields(c, u, SNDSchema.PKGS_TABLE_NAME);
+
+        Map<Integer, SuperPackage> superPackages = getAllFullSuperPkgs(c, u, packageExtraFields, pkgQus, eventId, errors);
+
+        Map<Integer, Map<Integer, SuperPackage>> topLevelEventDataSuperPkgs = getAllTopLevelEventDataSuperPkgs(c, u, Collections.singletonList(eventId), superPackages);
+
+        Event event = getAllEvents(c, u, Collections.singletonList(eventId), narrativeOptions, topLevelEventDataSuperPkgs, skipPermissionCheck, errors, eventExtraFields, eventDataExtraFields).get(eventId);
+
+        return event;
+
+    }
+
     /**
      * Query the Event table and retrieve rows for a set of eventIds and populate data/create narratives
      *
@@ -3514,6 +3699,10 @@ public class SNDManager
         List<Event> events = eventSelector.getArrayList(Event.class);
         Collection<Map<String, Object>> eventsExtensibleFields = eventSelector.getMapCollection();
 
+        TableSelector eventDataSelector = getTableSelector(c, u, eventIds, SNDSchema.EVENTDATA_TABLE_NAME, "EventId", null, null);
+        List<EventData> rawEventData = eventDataSelector.getArrayList(EventData.class);
+        Collection<Map<String, Object>> eventDataExtensibleFields = eventDataSelector.getMapCollection();
+
         //EventNotes grouped by EventId
         Map<Integer, String> eventNotes = getEventNotes(c, u, eventIds);
 
@@ -3521,7 +3710,7 @@ public class SNDManager
         Map<String, String> projectIdRevs = getProjectIdRevs(c, u, events.stream().map(Event::getParentObjectId).collect(Collectors.toList()));
 
         //EventData grouped by EventId
-        Map<Integer, List<EventData>> eventData = getAllEventData(c, u, topLevelSuperPkgs, eventDataExtraFields);
+        Map<Integer, List<EventData>> eventData = getAllEventData(c, topLevelSuperPkgs, rawEventData, eventDataExtensibleFields, eventDataExtraFields);
 
         // Build events from eventData, eventNotes, and project data and group by EventId
         Map<Integer, Event> eventsById = events.stream().collect(Collectors.toMap(Event::getEventId, (Event event) -> {
@@ -3561,16 +3750,11 @@ public class SNDManager
         return eventsById;
     }
 
+
     /**
-     * Query the SuperPackages table and retrieve all rows for a set of superPkgIds
-     *
-     * @param c
-     * @param u
-     * @param errors
-     * @return
+     * Recursively get all children for the super package which corresponds to pkgId
      */
-    @Nullable
-    private Map<Integer, SuperPackage> getAllFullSuperPackages(Container c, User u, BatchValidationException errors) {
+    private Map<Integer, SuperPackage> getAllFullSuperPkgs(Container c, User u, List<GWTPropertyDescriptor> packageExtraFields, QueryUpdateService pkgQus, @Nullable Integer eventId, BatchValidationException errors) {
 
         UserSchema schema = getSndUserSchema(c, u);
 
@@ -3580,47 +3764,79 @@ public class SNDManager
         sql.append(schema.getTable(SNDSchema.SUPERPKGS_TABLE_NAME), "sp");
         sql.append(" JOIN " + SNDSchema.NAME + "." + SNDSchema.PKGS_TABLE_NAME + " pkg");
         sql.append(" ON sp.PkgId = pkg.PkgId ");
+        if (eventId != null) {
+            sql.append(" INNER JOIN " + SNDSchema.NAME + "." + SNDSchema.EVENTDATA_TABLE_NAME + " ed");
+            sql.append(" ON ed.SuperPkgId = sp.SuperPkgId ");
+            sql.append(" WHERE ed.EventId = ? ").add(eventId);
+        }
         sql.append(" ORDER BY sp.SuperPkgId ");
 
         SqlSelector superPkgSelector = new SqlSelector(schema.getDbSchema(), sql);
         List<SuperPackage> superPackages = superPkgSelector.getArrayList(SuperPackage.class);
 
-        // Group All SuperPkgs by SuperPkgId
-        Map<Integer, SuperPackage> superPackagesById = superPackages.stream().collect(Collectors.toMap(SuperPackage::getSuperPkgId, superPackage -> superPackage));
+        List<Integer> pkgIds = superPackages.stream().map(SuperPackage::getPkgId).toList();
 
-        // All Child SuperPkgs grouped by TopLevelPkgId
-        Map<Integer, List<SuperPackage>> childSuperPackages = getAllFullChildSuperPkgs(c, u, true, errors);
+        List<SuperPackage> fullTreeSuperPkgs;
+
+        if (eventId != null) {
+            fullTreeSuperPkgs = new ArrayList<SuperPackage>();
+            pkgIds.forEach(pkgId -> {
+                SQLFragment packageSql = new SQLFragment("SELECT * FROM ");
+                packageSql.append(SNDSchema.NAME + "." + SNDSchema.SUPERPKGS_FUNCTION_NAME + "(?)").add(pkgId);
+                SqlSelector childSuperPkgSelector = new SqlSelector(schema.getDbSchema(), packageSql);
+                fullTreeSuperPkgs.addAll(childSuperPkgSelector.getArrayList(SuperPackage.class));
+            });
+
+        } else {
+            SQLFragment superPkgSql = new SQLFragment("SELECT * FROM ");
+            superPkgSql.append(SNDSchema.NAME + "." + SNDSchema.ALL_SUPERPKGS_FUNCTION_NAME + "()");
+            SqlSelector childSuperPkgSelector = new SqlSelector(schema.getDbSchema(), superPkgSql);
+            fullTreeSuperPkgs = childSuperPkgSelector.getArrayList(SuperPackage.class);
+            pkgIds = null;
+        }
+
+        Map<Integer, Map<Integer, String>> pkgCategoriesByPkgId;
+        if (pkgIds == null || !pkgIds.isEmpty()) {
+            pkgCategoriesByPkgId = getAllPackageCategories(c, u, pkgIds, errors);
+        } else {
+            pkgCategoriesByPkgId = new HashMap<>();
+        }
+
+
+        Map<Integer, List<SuperPackage>> childrenByParentId = fullTreeSuperPkgs.stream().filter(sp -> sp.getParentSuperPkgId() != null).collect(Collectors.groupingBy(SuperPackage::getParentSuperPkgId));
+
+        Map<Integer, SuperPackage> superPackagesById = superPackages.stream().filter(distinctByKey(sp -> sp.getSuperPkgId())).collect(Collectors.toMap(SuperPackage::getSuperPkgId, superPackage -> superPackage));
+
+        Map<Integer, List<SuperPackage>> childrenByTopLevelPkgId = getChildSuperPkgs(c, u, fullTreeSuperPkgs, childrenByParentId, pkgCategoriesByPkgId, packageExtraFields, pkgQus, true, errors);
 
         superPackagesById.forEach((superPkgId, superPackage) -> {
             Integer pkgId = superPackage.getPkgId();
             if (pkgId != null) {
-                List<Integer> pkgIds = Collections.singletonList(pkgId);
-                List<Package> packages = getPackages(c, u, pkgIds, true, true, true, errors);
+                List<Integer> packageIds = Collections.singletonList(pkgId);
+                List<Package> packages = getFullPackages(c, u, packageIds, pkgQus, packageExtraFields, fullTreeSuperPkgs, childrenByParentId, pkgCategoriesByPkgId, true, true, true, errors);
                 if (!packages.isEmpty()) {
                     superPackage.setPkg(packages.get(0));
                 }
-                superPackage.setChildPackages(childSuperPackages.get(pkgId));
+                superPackage.setChildPackages(childrenByTopLevelPkgId.get(pkgId));
             }
         });
 
         return superPackagesById;
-
     }
 
-    /**
-     * Recursively get all children for the super package which corresponds to pkgId
-     */
-    private Map<Integer, List<SuperPackage>> getAllFullChildSuperPkgs(Container c, User u, boolean includeFullSubpackages, BatchValidationException errors) {
+    public static <T> Predicate<T> distinctByKey(
+            Function<? super T, ?> keyExtractor) {
 
-        UserSchema schema = getSndUserSchema(c, u);
+        Map<Object, Boolean> seen = new ConcurrentHashMap<>();
+        return t -> seen.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
+    }
 
-        SQLFragment childSql = new SQLFragment("SELECT * FROM ");
-        childSql.append(SNDSchema.NAME + "." + SNDSchema.ALL_SUPERPKGS_FUNCTION_NAME + "()");
+    private Map<Integer, List<SuperPackage>> getChildSuperPkgs (Container c, User u, List<SuperPackage> allSuperPackages,
+                                    Map<Integer, List<SuperPackage>> childrenByParentId,
+                                    Map<Integer, Map<Integer, String>> pkgCategoriesByPkgId,
+                                    List<GWTPropertyDescriptor> packageExtraFields, QueryUpdateService pkgQus,
+                                    boolean includeFullSubpackages, BatchValidationException errors) {
 
-        SqlSelector selector = new SqlSelector(schema.getDbSchema(), childSql);
-        List<SuperPackage> allSuperPackages = selector.getArrayList(SuperPackage.class);
-
-        // Group results of TopLevelSuperPkgs by TopLevelPkgId
         Map<Integer, List<SuperPackage>> superPackagesByTopLevelPkgId = allSuperPackages.stream().collect(Collectors.groupingBy(SuperPackage::getTopLevelPkgId));
 
         superPackagesByTopLevelPkgId.forEach((topLevelPkgId, superPackages) -> {
@@ -3632,8 +3848,8 @@ public class SNDManager
                         .filter(sp -> sp.getParentSuperPkgId() != null)
                         .forEach((SuperPackage superPackage) -> {
                             if (includeFullSubpackages) {
-                                List<Integer> pkgIds = Collections.singletonList(superPackage.getPkgId());
-                                superPackage.setPkg(getPackages(c, u, pkgIds, true, true, true, errors).get(0));
+                                List<Integer> packageIds = Collections.singletonList(superPackage.getPkgId());
+                                superPackage.setPkg(getFullPackages(c, u, packageIds, pkgQus, packageExtraFields, allSuperPackages, childrenByParentId, pkgCategoriesByPkgId, true, true, true, errors).get(0));
                             }
                             if (superPackage.getParentSuperPkgId().intValue() == root.getSuperPkgId().intValue()) {
                                 children.add(addChildren(superPackage, superPackages));
@@ -3645,19 +3861,19 @@ public class SNDManager
         });
 
         return superPackagesByTopLevelPkgId;
-
     }
+
+
 
 
     /**
      * Query EventData table and populate attribute data for a set of top level SuperPackages
      *
      * @param c
-     * @param u
      * @param currentLevelSuperPkgs
      * @return
      */
-    private Map<Integer, List<EventData>> getAllEventData(Container c, User u, Map<Integer, Map<Integer, SuperPackage>> currentLevelSuperPkgs, List<GWTPropertyDescriptor> eventDataExtraFields) {
+    private Map<Integer, List<EventData>> getAllEventData(Container c, Map<Integer, Map<Integer, SuperPackage>> currentLevelSuperPkgs, List<EventData> allEventData, Collection<Map<String, Object>> eventDataExtensibleFields, List<GWTPropertyDescriptor> eventDataExtraFields) {
 
         if (currentLevelSuperPkgs == null) {
             return null;
@@ -3668,16 +3884,12 @@ public class SNDManager
                 .flatMap((Map<Integer, SuperPackage> map) -> map.keySet().stream())
                 .collect(Collectors.toList());
 
-        // EventData from query - SELECT * FROM EventData WHERE EventDataId IN {eventDataIds}
-        TableSelector eventDataSelector = getTableSelector(c, u, eventDataIds, SNDSchema.EVENTDATA_TABLE_NAME, "EventDataId", null, null);
-        List<EventData> allEventData = eventDataSelector.getArrayList(EventData.class);
-        Collection<Map<String, Object>> eventDataExtensibleFields = eventDataSelector.getMapCollection();
 
         // Child EventData grouped by EventId
-        Map<Integer, List<EventData>> childEventData = getChildEventData(c, u, eventDataIds);
+        Map<Integer, List<EventData>> childEventData = getChildEventData(allEventData, eventDataIds);
 
         // Build eventData from attributes and superPkgs and group by eventId
-        Map<Integer, List<EventData>> eventDataByEventId = allEventData.stream().map((EventData eventData) -> {
+        Map<Integer, List<EventData>> eventDataByEventId = allEventData.stream().filter(e -> eventDataIds.contains(e.getEventDataId())).map((EventData eventData) -> {
 
             Map<String, ObjectProperty> properties = OntologyManager.getPropertyObjects(c, eventData.getObjectURI());
             Map<Integer, SuperPackage> superPackagesById = currentLevelSuperPkgs.get(eventData.getEventId());
@@ -3706,7 +3918,7 @@ public class SNDManager
 
             if (nextLevelSuperPkgs != null && !nextLevelSuperPkgs.isEmpty()) {
                 // Recursion for next child level of sub packages
-                Map<Integer, List<EventData>> subEventData = getAllEventData(c, u, nextLevelSuperPkgs, eventDataExtraFields);
+                Map<Integer, List<EventData>> subEventData = getAllEventData(c, nextLevelSuperPkgs, allEventData, eventDataExtensibleFields, eventDataExtraFields);
                 if (subEventData != null) {
                     List<EventData> sorted = subEventData.get(eventData.getEventId()).stream().sorted(Comparator.comparing(
                                     (EventData child) -> nextLevelSuperPkgs.get(child.getEventId()).get(child.getEventDataId()).getTreePath()))
@@ -3725,20 +3937,16 @@ public class SNDManager
     /**
      * Get EventData objects for a list of ParentEventIds
      *
-     * @param c
-     * @param u
      * @param parentEventDataIds
      * @return
      */
-    private Map<Integer, List<EventData>> getChildEventData(Container c, User u, List<Integer> parentEventDataIds) {
+    private Map<Integer, List<EventData>> getChildEventData(List<EventData> allEventData, List<Integer> parentEventDataIds) {
 
         if (parentEventDataIds.isEmpty()) {
             return Collections.emptyMap();
         }
 
-        // EventData from query - SELECT * FROM EventData WHERE ParentEventDataId IN {parentEventDataIds}
-        TableSelector eventDataSelector = getTableSelector(c, u, parentEventDataIds, SNDSchema.EVENTDATA_TABLE_NAME, "ParentEventDataId", null, null);
-        List<EventData> childEventData = eventDataSelector.getArrayList(EventData.class);
+        List<EventData> childEventData = allEventData.stream().filter(e -> parentEventDataIds.contains(e.getParentEventDataId())).toList();
 
         // Group childEventData by eventId
         Map<Integer, List<EventData>> childEventDataByEventId = childEventData.stream().collect(Collectors.groupingBy(EventData::getEventId));

--- a/src/org/labkey/snd/SNDServiceImpl.java
+++ b/src/org/labkey/snd/SNDServiceImpl.java
@@ -336,7 +336,7 @@ public class SNDServiceImpl implements SNDService
     {
         BatchValidationException errors = new BatchValidationException();
 
-        Event event = SNDManager.get().getEvent(c, u, eventId, narrativeOptions, null, false, errors);
+        Event event = SNDManager.get().getEvent(c, u, eventId, narrativeOptions, false, errors);
 
         if (errors.hasErrors())
             throw new ApiUsageException(errors);


### PR DESCRIPTION
+ getAllPackageCategories will return a cached map of packageCategories to refrain from retrieving them for each package
+ New method override for addExtraFieldsToPackage to getextraFields for packages before any other operation to save from retrieving it every time
+ getFullPackages and getFullPackage get the package info from cached superPackages instead of database
+ New getEvent override method that uses the more optimized narrativeCache methods to get event info
- getAllFullSuperPkgs now accounts for either full database if eventId is null or select superPkgs for an eventId
- getAllEventData now receives a cached map of eventData objects instead of recursively retrieving eventData from database every time
- getChildEventData receives cached map instead of querying database
- SNDServiceImpl now calls the new override method for getEvent

Related JIRA Issue:

* https://txbiomed.atlassian.net/browse/MDP-99?atlOrigin=eyJpIjoiZjExOTRmMDlmMTcwNDk4NWFhMDExOGM2ZjRhZjgwODUiLCJwIjoiaiJ9