### PR TITLE
Explicitly replace eventDataIds during Event update

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -2567,10 +2567,7 @@ public class SNDManager
      */
     private void getEventDataRows(Container c, User u, Event event, EventData eventData, List<Map<String, Object>> eventDataRows) throws ValidationException
     {
-        if (eventData.getEventDataId() == null)
-        {
-            eventData.setEventDataId(SNDSequencer.EVENTDATAID.ensureId(c, null));
-        }
+        eventData.setEventDataId(SNDSequencer.EVENTDATAID.ensureId(c, null));
 
         String objectURI = insertExpObjectProperties(c, u, event, eventData);
         eventData.setObjectURI(objectURI);


### PR DESCRIPTION
#### Rationale
EventDatas are deleted and then recreated each time a row is updated, so the existing eventDataIds should not be reused.
