### PR TITLE
Update SND saveEvent endpoint to delete empty events

### DIFF
--- a/src/org/labkey/snd/SNDController.java
+++ b/src/org/labkey/snd/SNDController.java
@@ -1040,16 +1040,23 @@ public class SNDController extends SpringActionController
                 }
 
                 Event savedEvent = SNDService.get().saveEvent(getContainer(), getUser(), event, validateOnly);
-                response.put("event", savedEvent.toJSON(getContainer(), getUser()));
 
-                if (savedEvent.hasErrors())
-                {
-                    response.put("success", false);
-                }
-                else
-                {
+                if (savedEvent != null) {
+                    response.put("event", savedEvent.toJSON(getContainer(), getUser()));
+                    if (savedEvent.hasErrors())
+                    {
+                        response.put("success", false);
+                    }
+                    else
+                    {
+                        response.put("success", true);
+                    }
+                } else {
+                    response.put("event", null);
                     response.put("success", true);
                 }
+
+
             }
             return response;
         }

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -4178,7 +4178,7 @@ public class SNDManager
         }
 
         if (includeEmptySubPackages) {
-            
+
             List<Integer> eventDataSuperPkgIds = !nextLevelEventDataSuperPkgs.get(eventData.getEventId()).isEmpty()
                     ? nextLevelEventDataSuperPkgs.get(eventData.getEventId()).values().stream().map(SuperPackage::getSuperPkgId).toList()
                     : new ArrayList<>();

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -4177,13 +4177,14 @@ public class SNDManager
             nextLevelEventDataSuperPkgs.put(eventData.getEventId(), new HashMap<>());
         }
 
-        List<Integer> eventDataSuperPkgIds = !nextLevelEventDataSuperPkgs.get(eventData.getEventId()).isEmpty()
-                ? nextLevelEventDataSuperPkgs.get(eventData.getEventId()).values().stream().map(SuperPackage::getSuperPkgId).toList()
-                : new ArrayList<>();
-
-        AtomicInteger emptyEventDataId = new AtomicInteger(0); 
 
         if (includeEmptySubPackages) {
+            
+            List<Integer> eventDataSuperPkgIds = !nextLevelEventDataSuperPkgs.get(eventData.getEventId()).isEmpty()
+                    ? nextLevelEventDataSuperPkgs.get(eventData.getEventId()).values().stream().map(SuperPackage::getSuperPkgId).toList()
+                    : new ArrayList<>();
+
+            AtomicInteger emptyEventDataId = new AtomicInteger(0);
             Map<Integer, Map<Integer, SuperPackage>> eventDataSuperPkgs = nextLevelEventDataSuperPkgs;
             childSuperPkgs.values().stream()
                     .filter(superPkg -> !eventDataSuperPkgIds.contains(superPkg.getSuperPkgId()))

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -108,6 +108,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.snd.Event.EVENT_NOTE;
 import static org.labkey.api.snd.EventNarrativeOption.HTML_NARRATIVE;
 import static org.labkey.api.snd.EventNarrativeOption.REDACTED_HTML_NARRATIVE;
 import static org.labkey.api.snd.EventNarrativeOption.REDACTED_TEXT_NARRATIVE;
@@ -2939,6 +2940,52 @@ public class SNDManager
         {
             OntologyManager.deleteOntologyObjects(c, objectUri);
         }
+    }
+
+    public Event deleteEvent(Container c, User u, Event event) {
+
+        if (!event.hasErrors()) {
+            UserSchema schema = getSndUserSchemaAdminRole(c, u);
+            TableInfo eventTable = getTableInfo(schema, SNDSchema.EVENTS_TABLE_NAME);
+            QueryUpdateService eventQus = getQueryUpdateService(eventTable);
+
+            BatchValidationException errors = new BatchValidationException();
+
+            try (DbScope.Transaction tx = eventTable.getSchema().getScope().ensureTransaction())
+            {
+                deleteEventDatas(c, u, event.getEventId());
+                deleteEventNotes(c, u, event.getEventId());
+                deleteEventsCache(c, u, event.getEventId());
+                NarrativeAuditProvider.addAuditEntry(c, u, event.getEventId(), event.getSubjectId(), event.getDate(), "", event.getQcState(), "Delete event");
+
+                Map<String, Object> row;
+                List<Map<String, Object>> rows = new ArrayList<>();
+                row = new HashMap<>();
+                row.put("EventId", event.getEventId());
+                rows.add(row);
+                eventQus.deleteRows(u, c, rows, null, null);
+
+                tx.commit();
+
+            } catch (QueryUpdateServiceException | BatchValidationException | SQLException | InvalidKeyException e) {
+
+                event.setException(new ValidationException(e.getMessage(), ValidationException.SEVERITY.ERROR));
+
+            } finally
+            {
+                if (errors.hasErrors())
+                {
+                    event.addBatchValidationExceptions(errors);
+                }
+                // Errors, warnings and info are embedded in the event so don't override
+                else if (!event.hasErrorsWarningsOrInfo())
+                {
+                    event = getEvent(c, u, event.getEventId(), null, null, true, errors);
+                }
+            }
+        }
+
+        return event;
     }
 
     /**

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -4177,7 +4177,6 @@ public class SNDManager
             nextLevelEventDataSuperPkgs.put(eventData.getEventId(), new HashMap<>());
         }
 
-
         if (includeEmptySubPackages) {
 
             List<Integer> eventDataSuperPkgIds = !nextLevelEventDataSuperPkgs.get(eventData.getEventId()).isEmpty()
@@ -4185,6 +4184,7 @@ public class SNDManager
                     : new ArrayList<>();
 
             AtomicInteger emptyEventDataId = new AtomicInteger(0);
+
             Map<Integer, Map<Integer, SuperPackage>> eventDataSuperPkgs = nextLevelEventDataSuperPkgs;
             childSuperPkgs.values().stream()
                     .filter(superPkg -> !eventDataSuperPkgIds.contains(superPkg.getSuperPkgId()))

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -4178,13 +4178,12 @@ public class SNDManager
         }
 
         if (includeEmptySubPackages) {
-
+            
             List<Integer> eventDataSuperPkgIds = !nextLevelEventDataSuperPkgs.get(eventData.getEventId()).isEmpty()
                     ? nextLevelEventDataSuperPkgs.get(eventData.getEventId()).values().stream().map(SuperPackage::getSuperPkgId).toList()
                     : new ArrayList<>();
 
             AtomicInteger emptyEventDataId = new AtomicInteger(0);
-
             Map<Integer, Map<Integer, SuperPackage>> eventDataSuperPkgs = nextLevelEventDataSuperPkgs;
             childSuperPkgs.values().stream()
                     .filter(superPkg -> !eventDataSuperPkgIds.contains(superPkg.getSuperPkgId()))

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -4137,7 +4137,7 @@ public class SNDManager
             List<EventData>> childEventData, Map<Integer, Map<Integer, SuperPackage>> currentLevelSuperPkgs,
                                                                                     boolean includeEmptySubPackages, boolean hasSubpackages) {
 
-        if (!childEventData.containsKey(eventData.getEventId()) && !(includeEmptySubPackages && hasSubpackages)) {
+        if ((!includeEmptySubPackages && !childEventData.containsKey(eventData.getEventId())) || (includeEmptySubPackages && !hasSubpackages)) {
             return null;
         }
 

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -4137,7 +4137,7 @@ public class SNDManager
             List<EventData>> childEventData, Map<Integer, Map<Integer, SuperPackage>> currentLevelSuperPkgs,
                                                                                     boolean includeEmptySubPackages, boolean hasSubpackages) {
 
-        if (!childEventData.containsKey(eventData.getEventId()) || !hasSubpackages) {
+        if (!childEventData.containsKey(eventData.getEventId()) && !(includeEmptySubPackages && hasSubpackages)) {
             return null;
         }
 
@@ -4157,7 +4157,7 @@ public class SNDManager
         Map<Integer, Map<Integer, SuperPackage>> nextLevelEventDataSuperPkgs = new HashMap<>();
         nextLevelEventDataSuperPkgs.put(eventData.getEventId(), new HashMap<>());
 
-        if (!childSuperPkgs.isEmpty()) {
+        if (!childSuperPkgs.isEmpty() && !childEventData.isEmpty()) {
             Map<Integer, SuperPackage> children = childSuperPkgs;
             nextLevelEventDataSuperPkgs = childEventData.get(eventData.getEventId())
                     .stream()

--- a/src/org/labkey/snd/SNDServiceImpl.java
+++ b/src/org/labkey/snd/SNDServiceImpl.java
@@ -351,7 +351,18 @@ public class SNDServiceImpl implements SNDService
         {
             if (event.getEventId() != null && SNDManager.get().eventExists(c, u, event.getEventId()))
             {
-                event = SNDManager.get().updateEvent(c, u, event, validateOnly);
+                if ((event.getEventData() == null || event.getEventData().isEmpty()) &&
+                        (!event.getEventNotesRow(c).containsKey("note") ||
+                                event.getEventNotesRow(c).get("note") == null ||
+                                event.getEventNotesRow(c).get("note").toString().trim().length() == 0))
+                {
+                    event = SNDManager.get().deleteEvent(c, u, event);
+                }
+                else
+                {
+                    event = SNDManager.get().updateEvent(c, u, event, validateOnly);
+                }
+
             }
             else
             {


### PR DESCRIPTION
- Added deleteEvent method to SNDManager that Deletes an event and its corresponding eventData, eventNotes, and eventsCache from the database by eventId
- Added code to the SNDServiceImpl saveEvent method that checks an event for empty eventData and eventNotes and calls deleteEvent instead of updateEvent 

* Related JIRA Issue: https://txbiomed.atlassian.net/browse/MDP-119?atlOrigin=eyJpIjoiMmVkYmNjMjc0ZGI4NDMyYmI0YmViM2FiNDI3MzllOTAiLCJwIjoiaiJ9
