### PR TITLE
Add deleteEvent functionality to saveEvent API endpoint

### DIFF
--- a/src/org/labkey/snd/SNDController.java
+++ b/src/org/labkey/snd/SNDController.java
@@ -1040,14 +1040,19 @@ public class SNDController extends SpringActionController
                 }
 
                 Event savedEvent = SNDService.get().saveEvent(getContainer(), getUser(), event, validateOnly);
-                response.put("event", savedEvent.toJSON(getContainer(), getUser()));
 
-                if (savedEvent.hasErrors())
-                {
-                    response.put("success", false);
-                }
-                else
-                {
+                if (savedEvent != null) {
+                    response.put("event", savedEvent.toJSON(getContainer(), getUser()));
+                    if (savedEvent.hasErrors())
+                    {
+                        response.put("success", false);
+                    }
+                    else
+                    {
+                        response.put("success", true);
+                    }
+                } else {
+                    response.put("event", null);
                     response.put("success", true);
                 }
             }

--- a/src/org/labkey/snd/SNDServiceImpl.java
+++ b/src/org/labkey/snd/SNDServiceImpl.java
@@ -351,7 +351,17 @@ public class SNDServiceImpl implements SNDService
         {
             if (event.getEventId() != null && SNDManager.get().eventExists(c, u, event.getEventId()))
             {
-                event = SNDManager.get().updateEvent(c, u, event, validateOnly);
+                if ((event.getEventData() == null || event.getEventData().isEmpty()) &&
+                        (!event.getEventNotesRow(c).containsKey("note") ||
+                                event.getEventNotesRow(c).get("note") == null ||
+                                event.getEventNotesRow(c).get("note").toString().trim().length() == 0))
+                {
+                    event = SNDManager.get().deleteEvent(c, u, event);
+                }
+                else
+                {
+                    event = SNDManager.get().updateEvent(c, u, event, validateOnly);
+                }
             }
             else
             {


### PR DESCRIPTION
+ Added deleteEvent method to SNDManager that removes an event and its associated eventData, eventNote, and eventCache
+ Added logic to check for empty eventData and eventNote on an event object in the saveEvent method in SNDServiceImpl and calls deleteEvent instead of updateEvent
+ Updated response in SNDController to be empty if an event was successfully deleted

* Related JIRA Issue: https://txbiomed.atlassian.net/browse/MDP-119?atlOrigin=eyJpIjoiYTY2MDYxZDRmNDkzNGE4Y2I4NjY2Y2NmMzZjMDU1YmQiLCJwIjoiaiJ9
