### PR TITLE
Handle getEvent processing where multiple top-level EventData entries have the same SuperPkgId

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -4279,6 +4279,7 @@ public class SNDManager
                 // Group subpackage superPkgIds for the repeated parent superPkgs by their parentEventDataId
                 Map<Integer, List<Integer>> childSuperPkgIdsByParentEventDataId = childEventData.get(eventData.getEventId()).stream()
                         .filter(e -> e.getParentEventDataId() != null
+                                && nextLevelEventDataSuperPkgs.get(eventData.getEventId()).containsKey(e.getEventDataId())
                                 && repeatedIds.contains(nextLevelEventDataSuperPkgs.get(eventData.getEventId()).get(e.getEventDataId()).getLeft().getParentSuperPkgId()))  // Ensure parentEventDataId exists
                         .collect(Collectors.groupingBy(
                                 EventData::getParentEventDataId,  // Group by parentEventDataId


### PR DESCRIPTION
+ Added logic to getBulkEventData and getNextLevelEventDataSuperPkgs that saves a child's ParentSuperPkgId in the nextLevelEventDataSuperPkgs HashMap if multiple parents share it's parentSuperPkgId. 

i.e. - Map<Integer, Map<Integer, SuperPackage>> is now Map<Integer, Map<Integer, **Pair<SuperPackage, Integer>**> where the Pair structure is SuperPackage and associated parentEventDataId

+ Updated & optimized comments throughout the bulk processing SND code because it took me awhile to remember what it was doing when going through the code initially.
