### PR TITLE
Use eventId event notes merge

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -3113,7 +3113,7 @@ public class SNDManager
                 log.info("Deleting affected narrative cache rows.");
                 deleteNarrativeCacheRows(container, user, rows, errors);
                 //repopulate
-                if (isUpdate)
+                if (!errors.hasErrors() && isUpdate)
                 {
                     log.info("Repopulate affected rows in narrative cache.");
                     populateNarrativeCache(container, user, eventIds, errors, log);
@@ -3142,7 +3142,7 @@ public class SNDManager
         }
         catch (InvalidKeyException | BatchValidationException | QueryUpdateServiceException | SQLException e)
         {
-            e.printStackTrace();
+            errors.addRowError(new ValidationException(e.getMessage()));
         }
     }
 

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -36,6 +36,7 @@ import org.labkey.snd.SNDUserSchema;
 import org.labkey.snd.security.permissions.SNDViewerPermission;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -108,6 +109,14 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
             return result;
         }
 
+        @Override
+        public void configureDataIteratorContext(DataIteratorContext context)
+        {
+            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE)
+            {
+                context.addAlternateKeys(Collections.singleton("EventId"));
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Since the event note may not have an event note Id when ETLing data, use the eventId when merging.

Also do a little cleanup on error handling when updating narrative caches.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6000

#### Changes
* Override configureDataIteratorContext to use EventId as a key when doing a merge.
* Ensure errors are caught and don't continue if delete narrative cache fails.
