### PR TITLE
Handle Merge on EventId for EventNotes and Speed up NarrativeCache population for iterative updates

### DIFF
--- a/api-src/org/labkey/api/snd/SNDSequencer.java
+++ b/api-src/org/labkey/api/snd/SNDSequencer.java
@@ -24,10 +24,10 @@ public enum SNDSequencer
     PKGID ("org.labkey.snd.api.Package", 10000),
     SUPERPKGID ("org.labkey.snd.api.SuperPackage", 10000),
     CATEGORYID ("org.labkey.snd.api.Categories", 100),
-    PROJECTID ("org.labkey.snd.api.Project", 1000),
+    PROJECTID ("org.labkey.snd.api.Project", 10000),
     PROJECTITEMID ("org.labkey.snd.api.ProjectItem", 30000),
     EVENTID ("org.labkey.snd.api.Event", 2000000),
-    EVENTDATAID ("org.labkey.snd.api.EventData", 3500000);
+    EVENTDATAID ("org.labkey.snd.api.EventData", 5000000);
 
     private String sequenceName;
     private int minId;

--- a/api-src/org/labkey/api/snd/SNDService.java
+++ b/api-src/org/labkey/api/snd/SNDService.java
@@ -67,7 +67,7 @@ public interface SNDService
     void fillInNarrativeCache(Container c, User u, Logger logger);
     void clearNarrativeCache(Container c, User u);
     void deleteNarrativeCacheRows(Container c, User u, List<Map<String, Object>> eventIds);
-    void populateNarrativeCache(Container c, User u, List<Integer> eventIds, Logger logger);
+    void populateNarrativeCache(Container c, User u, List<Integer> eventIds, Logger logger, boolean isUpdate);
     Map<Integer, Category> getAllCategories(Container c, User u);
     Integer getQCStateId(Container c, User u, QCStateEnum qcState);
     QCStateEnum getQCState(Container c, User u, int qcStateId);

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -4328,6 +4328,7 @@ public class SNDManager
         return eventNotesById;
     }
 
+
     /**
      * Query the Projects table and retrieve the ID concatenated with RevisionNum for a set of objectIds
      *
@@ -4382,5 +4383,15 @@ public class SNDManager
             filter.addCondition(FieldKey.fromParts(isNullColumn), null, CompareType.ISBLANK);
         }
         return new TableSelector(tableInfo, filter, sort);
+    }
+
+    public EventNote getEventNote(Container c, User u, int eventId) {
+        TableSelector eventNoteSelector = getTableSelector(c, u, Collections.singletonList(eventId), SNDSchema.EVENTNOTES_TABLE_NAME, Event.EVENT_ID, null, null);
+        List<EventNote> eventNotes = eventNoteSelector.getArrayList(EventNote.class);
+        if (!eventNotes.isEmpty()) {
+            return eventNotes.get(0);
+        } else {
+            return null;
+        }
     }
 }

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -3116,7 +3116,7 @@ public class SNDManager
                 if (!errors.hasErrors() && isUpdate)
                 {
                     log.info("Repopulate affected rows in narrative cache.");
-                    populateNarrativeCache(container, user, eventIds, errors, log);
+                    populateNarrativeCache(container, user, eventIds, errors, log, false);
                 }
             }
 
@@ -3182,13 +3182,13 @@ public class SNDManager
 
         List<Integer> eventIds = selector.getArrayList(Integer.class);
 
-        populateNarrativeCache(c, u, eventIds, errors, logger);
+        populateNarrativeCache(c, u, eventIds, errors, logger, true);
     }
 
     /**
      * Populate specific event narratives in narrative cache.
      */
-    public void populateNarrativeCache(Container c, User u, List<Integer> eventIds, BatchValidationException errors, @Nullable Logger logger)
+    public void populateNarrativeCache(Container c, User u, List<Integer> eventIds, BatchValidationException errors, @Nullable Logger logger, boolean isFullReload)
     {
         UserSchema sndSchema = getSndUserSchemaAdminRole(c, u);
         QueryUpdateService eventsCacheQus = getNewQueryUpdateService(sndSchema, SNDSchema.EVENTSCACHE_TABLE_NAME);
@@ -3208,7 +3208,7 @@ public class SNDManager
             logger.info("Generating narratives.");
         }
 
-        Map<Integer, SuperPackage> superPackages = getBulkSuperPkgs(c, u, packageExtraFields, pkgQus, null, lookups, errors);
+        Map<Integer, SuperPackage> superPackages = getBulkSuperPkgs(c, u, packageExtraFields, pkgQus, isFullReload ? null : eventIds, lookups, errors, isFullReload);
 
         AtomicInteger count = new AtomicInteger(0);
 
@@ -3801,7 +3801,7 @@ public class SNDManager
         List<GWTPropertyDescriptor> packageExtraFields = getExtraFields(c, u, SNDSchema.PKGS_TABLE_NAME);
 
         // Retrieve all SuperPackages associated with a single event
-        Map<Integer, SuperPackage> superPackages = getBulkSuperPkgs(c, u, packageExtraFields, pkgQus, eventId, lookups, errors);
+        Map<Integer, SuperPackage> superPackages = getBulkSuperPkgs(c, u, packageExtraFields, pkgQus, Collections.singletonList(eventId), lookups, errors, false);
 
         // Map top-level EventDataIds to associated SuperPackage objects and group by EventId
         Map<Integer, Map<Integer, SuperPackage>> topLevelEventDataSuperPkgs = getBulkTopLevelEventDataSuperPkgs(c, u, Collections.singletonList(eventId), superPackages);
@@ -3911,14 +3911,14 @@ public class SNDManager
      * @param u User object representing the current user.
      * @param packageExtraFields Extra fields related to the SuperPackage that need to be included in the response.
      * @param pkgQus QueryUpdateService for handling SuperPackage updates.
-     * @param eventId The ID of the event for which SuperPackages should be retrieved. Can be null to retrieve all SuperPackages.
+     * @param eventIds The ID of the event for which SuperPackages should be retrieved. Can be null to retrieve all SuperPackages.
      * @param lookups Map for additional lookup criteria or filtering, used to retrieve SuperPackages.
      * @param errors BatchValidationException object used to accumulate any errors encountered during the process.
      *
      * @return A map of SuperPackage objects, keyed by SuperPkgId.
      */
-    private Map<Integer, SuperPackage> getBulkSuperPkgs(Container c, User u, List<GWTPropertyDescriptor> packageExtraFields, QueryUpdateService pkgQus, @Nullable Integer eventId,
-                                                        Map<String, String> lookups, BatchValidationException errors) {
+    private Map<Integer, SuperPackage> getBulkSuperPkgs(Container c, User u, List<GWTPropertyDescriptor> packageExtraFields, QueryUpdateService pkgQus, @Nullable List<Integer> eventIds,
+                                                        Map<String, String> lookups, BatchValidationException errors, boolean isFullReload) {
 
         UserSchema schema = getSndUserSchema(c, u);
 
@@ -3929,10 +3929,15 @@ public class SNDManager
         sql.append(schema.getTable(SNDSchema.SUPERPKGS_TABLE_NAME), "sp");
         sql.append(" JOIN " + SNDSchema.NAME + "." + SNDSchema.PKGS_TABLE_NAME + " pkg");
         sql.append(" ON sp.PkgId = pkg.PkgId ");
-        if (eventId != null) {
+        if (eventIds != null) {
             sql.append(" INNER JOIN " + SNDSchema.NAME + "." + SNDSchema.EVENTDATA_TABLE_NAME + " ed");
             sql.append(" ON ed.SuperPkgId = sp.SuperPkgId ");
-            sql.append(" WHERE ed.EventId = ? ").add(eventId);
+            sql.append(" WHERE ed.EventId IN ( ");
+            ArrayDeque<Integer> eventIdsQueue = new ArrayDeque<>(eventIds);
+            while (eventIdsQueue.size() > 1) {
+                sql.append("?, ").add(eventIdsQueue.pop());
+            }
+            sql.append("?) ").add(eventIdsQueue.pop());
         }
         sql.append(" ORDER BY sp.SuperPkgId ");
 
@@ -3943,7 +3948,7 @@ public class SNDManager
 
         List<SuperPackage> fullTreeSuperPkgs;
 
-        if (eventId != null) {
+        if (!isFullReload) {
             fullTreeSuperPkgs = new ArrayList<SuperPackage>();
             pkgIds.forEach(pkgId -> {
                 SQLFragment packageSql = new SQLFragment("SELECT * FROM ");

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -3113,7 +3113,7 @@ public class SNDManager
                 log.info("Deleting affected narrative cache rows.");
                 deleteNarrativeCacheRows(container, user, rows, errors);
                 //repopulate
-                if (isUpdate)
+                if (!errors.hasErrors() && isUpdate)
                 {
                     log.info("Repopulate affected rows in narrative cache.");
                     populateNarrativeCache(container, user, eventIds, errors, log);
@@ -3142,7 +3142,7 @@ public class SNDManager
         }
         catch (InvalidKeyException | BatchValidationException | QueryUpdateServiceException | SQLException e)
         {
-            e.printStackTrace();
+            errors.addRowError(new ValidationException(e.getMessage()));
         }
     }
 

--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -4389,14 +4389,4 @@ public class SNDManager
         }
         return new TableSelector(tableInfo, filter, sort);
     }
-
-    public EventNote getEventNote(Container c, User u, int eventId) {
-        TableSelector eventNoteSelector = getTableSelector(c, u, Collections.singletonList(eventId), SNDSchema.EVENTNOTES_TABLE_NAME, Event.EVENT_ID, null, null);
-        List<EventNote> eventNotes = eventNoteSelector.getArrayList(EventNote.class);
-        if (!eventNotes.isEmpty()) {
-            return eventNotes.get(0);
-        } else {
-            return null;
-        }
-    }
 }

--- a/src/org/labkey/snd/SNDServiceImpl.java
+++ b/src/org/labkey/snd/SNDServiceImpl.java
@@ -558,11 +558,11 @@ public class SNDServiceImpl implements SNDService
     }
 
     @Override
-    public void populateNarrativeCache(Container c, User u, List<Integer> eventIds, Logger logger)
+    public void populateNarrativeCache(Container c, User u, List<Integer> eventIds, Logger logger, boolean isUpdate)
     {
         BatchValidationException errors = new BatchValidationException();
 
-        SNDManager.get().populateNarrativeCache(c, u, eventIds, errors, logger);
+        SNDManager.get().populateNarrativeCache(c, u, eventIds, errors, logger, isUpdate);
 
         if (errors.hasErrors())
             throw new ApiUsageException(errors);

--- a/src/org/labkey/snd/query/EventNotesDataIterator.java
+++ b/src/org/labkey/snd/query/EventNotesDataIterator.java
@@ -1,0 +1,92 @@
+package org.labkey.snd.query;
+
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.dataiterator.AbstractDataIterator;
+import org.labkey.api.dataiterator.DataIterator;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.DataIteratorUtil;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.User;
+import org.labkey.api.util.logging.LogHelper;
+import org.labkey.snd.SNDManager;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class EventNotesDataIterator extends AbstractDataIterator
+{
+    private static final SNDManager _sndManager = SNDManager.get();
+    private static final String EVENT_ID_COL = "eventId";
+    private static final String EVENT_NOTE_ID_COL = "eventNoteId";
+    private User _user;
+    private Container _container;
+    private int _eventIdColIndex;
+    private Set<Integer> _eventIds = new HashSet<>();
+    private DataIterator _in;
+    private Logger log = LogHelper.getLogger(EventNotesDataIterator.class, "Fill out event notes");
+
+    public static DataIterator wrap(DataIterator in, DataIteratorContext context, Container c, User u)
+    {
+        return new EventNotesDataIterator(in, context, c, u);
+    }
+
+    private EventNotesDataIterator(DataIterator in, DataIteratorContext context, Container c, User u)
+    {
+        super(context);
+        _user = u;
+        _container = c;
+        _in = in;
+
+        _eventIdColIndex = DataIteratorUtil.createColumnNameMap(in).get(EVENT_ID_COL);
+    }
+
+    @Override
+    public int getColumnCount()
+    {
+        return _in.getColumnCount();
+    }
+
+    @Override
+    public ColumnInfo getColumnInfo(int i)
+    {
+        return _in.getColumnInfo(i);
+    }
+
+    @Override
+    public boolean next() throws BatchValidationException
+    {
+        boolean hasNext = _in.next();
+        if (hasNext)
+        {
+            Integer eventId = (Integer)_in.get(_eventIdColIndex);
+            _eventIds.add(eventId);
+        }
+        else
+        {
+            UserSchema schema = SNDManager.getSndUserSchema(_container, _user);
+
+            // Add a post commit task to update the narrative cache after the transaction updating the notes is committed.
+            SNDManager.get().getTableInfo(schema, "EventNotes").getSchema().getScope().addCommitTask(() -> {
+                _sndManager.updateNarrativeCache(_container, _user, _eventIds, log);
+            }, DbScope.CommitTaskOption.POSTCOMMIT);
+        }
+        return hasNext;
+    }
+
+    @Override
+    public Object get(int i)
+    {
+        return _in.get(i);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        _in.close();
+    }
+}

--- a/src/org/labkey/snd/query/EventNotesDataIterator.java
+++ b/src/org/labkey/snd/query/EventNotesDataIterator.java
@@ -22,7 +22,6 @@ public class EventNotesDataIterator extends AbstractDataIterator
 {
     private static final SNDManager _sndManager = SNDManager.get();
     private static final String EVENT_ID_COL = "eventId";
-    private static final String EVENT_NOTE_ID_COL = "eventNoteId";
     private User _user;
     private Container _container;
     private int _eventIdColIndex;

--- a/src/org/labkey/snd/query/EventNotesDataIteratorBuilder.java
+++ b/src/org/labkey/snd/query/EventNotesDataIteratorBuilder.java
@@ -1,0 +1,33 @@
+package org.labkey.snd.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.dataiterator.DataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.DataIteratorUtil;
+import org.labkey.api.security.User;
+
+public class EventNotesDataIteratorBuilder implements DataIteratorBuilder
+{
+    private final DataIteratorBuilder in;
+    private final User user;
+    private final Container container;
+
+    public EventNotesDataIteratorBuilder(@NotNull DataIteratorBuilder in, User user, Container container)
+    {
+        this.in = in;
+        this.user = user;
+        this.container = container;
+    }
+
+    @Override
+    public DataIterator getDataIterator(DataIteratorContext context)
+    {
+        DataIterator it = in.getDataIterator(context);
+        DataIterator in = DataIteratorUtil.wrapMap(it, false);
+        return EventNotesDataIterator.wrap(in, context, container, user);
+    }
+}
+
+

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -39,8 +39,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 {
@@ -98,7 +96,7 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
         {
             Logger log = SNDManager.getLogger(configParameters, EventNotesTable.class);
             // Large merge triggers importRows path
-            int result = 0;
+            int result;
             if (getRowCount(rows, configParameters, errors) > SNDManager.MAX_MERGE_ROWS)
             {
                 log.info("More than " + SNDManager.MAX_MERGE_ROWS + " rows. using importRows method.");
@@ -107,17 +105,9 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
             else
             {
                 log.info("Merging rows.");
+                DataIteratorBuilder dib = new EventNotesDataIteratorBuilder(rows, user, container);
 
-                DataIteratorContext context = getDataIteratorContext(errors, QueryUpdateService.InsertOption.MERGE, configParameters);
-
-                Set<Integer> eventIds = rows.getDataIterator(context).stream()
-                        .filter(row -> row.containsKey("eventId"))
-                        .map(row -> (Integer) row.get("eventId"))
-                        .collect(Collectors.toSet());
-
-                result = super.mergeRows(user, container, rows, errors, configParameters, extraScriptContext);
-
-                _sndManager.updateNarrativeCache(container, user, eventIds, log);
+                result = super.mergeRows(user, container, dib, errors, configParameters, extraScriptContext);
             }
             return result;
         }

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -21,10 +21,8 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
-import org.labkey.api.dataiterator.ListofMapsDataIterator;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
@@ -32,8 +30,6 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.snd.Event;
-import org.labkey.api.snd.EventNote;
 import org.labkey.api.snd.SNDService;
 import org.labkey.snd.SNDManager;
 import org.labkey.snd.SNDUserSchema;
@@ -114,37 +110,12 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 
                 DataIteratorContext context = getDataIteratorContext(errors, QueryUpdateService.InsertOption.MERGE, configParameters);
 
-                List<Map<String, Object>> rowsWithEventNoteId = rows.getDataIterator(context).stream().map(row -> {
-                            EventNote eventNote = _sndManager.getEventNote(container, user, (int) row.get("eventId"));
-                            if (eventNote != null) {
-                                row.put("eventNoteId", eventNote.getEventNoteId());
-                            }
-                            return row;
-                        }
-                ).toList();
-
                 Set<Integer> eventIds = rows.getDataIterator(context).stream()
                         .filter(row -> row.containsKey("eventId"))
                         .map(row -> (Integer) row.get("eventId"))
                         .collect(Collectors.toSet());
 
-                Map<Boolean, List<Map<String, Object>>> partitionedMaps = rowsWithEventNoteId.stream().collect(Collectors.partitioningBy(row -> row.containsKey("eventNoteId") && row.get("eventNoteId") != null));
-
-                List<Map<String, Object>> mapsWithEventNoteId = partitionedMaps.get(true);
-                List<Map<String, Object>> mapsWithoutEventNoteId = partitionedMaps.get(false);
-
-                DataIteratorBuilder iteratorWithEventNoteId;
-                DataIteratorBuilder iteratorWithoutEventNoteId;
-
-                if (!mapsWithEventNoteId.isEmpty()) {
-                    iteratorWithEventNoteId = new ListofMapsDataIterator.Builder(mapsWithEventNoteId.get(0).keySet(), mapsWithEventNoteId);
-                    result += _importRowsUsingDIB(user, container, iteratorWithEventNoteId, null, context, extraScriptContext);
-                }
-
-                if (!mapsWithoutEventNoteId.isEmpty()) {
-                    iteratorWithoutEventNoteId = new ListofMapsDataIterator.Builder(mapsWithoutEventNoteId.get(0).keySet(), mapsWithoutEventNoteId);
-                    result += super.importRows(user, container, iteratorWithoutEventNoteId, errors, configParameters, extraScriptContext);
-                }
+                result = super.mergeRows(user, container, rows, errors, configParameters, extraScriptContext);
 
                 _sndManager.updateNarrativeCache(container, user, eventIds, log);
             }

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -21,8 +21,10 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.ListofMapsDataIterator;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
@@ -30,6 +32,8 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.snd.Event;
+import org.labkey.api.snd.EventNote;
 import org.labkey.api.snd.SNDService;
 import org.labkey.snd.SNDManager;
 import org.labkey.snd.SNDUserSchema;
@@ -39,6 +43,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
 {
@@ -68,6 +74,7 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
         }
 
         private final SNDService _sndService = SNDService.get();
+        private final SNDManager _sndManager = SNDManager.get();
 
         private int getRowCount(DataIteratorBuilder rows, @Nullable Map<Enum,Object> configParameters, BatchValidationException errors)
         {
@@ -104,7 +111,41 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
             else
             {
                 log.info("Merging rows.");
-                result = super.mergeRows(user, container, rows, errors, configParameters, extraScriptContext);
+
+                DataIteratorContext context = getDataIteratorContext(errors, QueryUpdateService.InsertOption.MERGE, configParameters);
+
+                List<Map<String, Object>> rowsWithEventNoteId = rows.getDataIterator(context).stream().map(row -> {
+                            EventNote eventNote = _sndManager.getEventNote(container, user, (int) row.get("eventId"));
+                            if (eventNote != null) {
+                                row.put("eventNoteId", eventNote.getEventNoteId());
+                            }
+                            return row;
+                        }
+                ).toList();
+
+                Set<Integer> eventIds = rows.getDataIterator(context).stream()
+                        .filter(row -> row.containsKey("eventId"))
+                        .map(row -> (Integer) row.get("eventId"))
+                        .collect(Collectors.toSet());
+
+                Map<Boolean, List<Map<String, Object>>> partitionedMaps = rowsWithEventNoteId.stream().collect(Collectors.partitioningBy(row -> row.containsKey("eventNoteId") && row.get("eventNoteId") != null));
+
+                List<Map<String, Object>> mapsWithEventNoteId = partitionedMaps.get(true);
+                List<Map<String, Object>> mapsWithoutEventNoteId = partitionedMaps.get(false);
+
+                DataIteratorBuilder iteratorWithEventNoteId;
+                DataIteratorBuilder iteratorWithoutEventNoteId;
+
+                if (!mapsWithoutEventNoteId.isEmpty()) {
+                    iteratorWithoutEventNoteId = new ListofMapsDataIterator.Builder(mapsWithoutEventNoteId.get(0).keySet(), mapsWithoutEventNoteId);
+                    result += super.importRows(user, container, iteratorWithoutEventNoteId, errors, configParameters, extraScriptContext);
+                }
+                if (!mapsWithEventNoteId.isEmpty()) {
+                    iteratorWithEventNoteId = new ListofMapsDataIterator.Builder(mapsWithEventNoteId.get(0).keySet(), mapsWithEventNoteId);
+                    result += _importRowsUsingDIB(user, container, iteratorWithEventNoteId, null, context, extraScriptContext);
+                }
+
+                _sndManager.updateNarrativeCache(container, user, eventIds, log);
             }
             return result;
         }

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -136,13 +136,14 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
                 DataIteratorBuilder iteratorWithEventNoteId;
                 DataIteratorBuilder iteratorWithoutEventNoteId;
 
-                if (!mapsWithoutEventNoteId.isEmpty()) {
-                    iteratorWithoutEventNoteId = new ListofMapsDataIterator.Builder(mapsWithoutEventNoteId.get(0).keySet(), mapsWithoutEventNoteId);
-                    result += super.importRows(user, container, iteratorWithoutEventNoteId, errors, configParameters, extraScriptContext);
-                }
                 if (!mapsWithEventNoteId.isEmpty()) {
                     iteratorWithEventNoteId = new ListofMapsDataIterator.Builder(mapsWithEventNoteId.get(0).keySet(), mapsWithEventNoteId);
                     result += _importRowsUsingDIB(user, container, iteratorWithEventNoteId, null, context, extraScriptContext);
+                }
+
+                if (!mapsWithoutEventNoteId.isEmpty()) {
+                    iteratorWithoutEventNoteId = new ListofMapsDataIterator.Builder(mapsWithoutEventNoteId.get(0).keySet(), mapsWithoutEventNoteId);
+                    result += super.importRows(user, container, iteratorWithoutEventNoteId, errors, configParameters, extraScriptContext);
                 }
 
                 _sndManager.updateNarrativeCache(container, user, eventIds, log);

--- a/src/org/labkey/snd/query/EventNotesTable.java
+++ b/src/org/labkey/snd/query/EventNotesTable.java
@@ -36,6 +36,7 @@ import org.labkey.snd.SNDUserSchema;
 import org.labkey.snd.security.permissions.SNDViewerPermission;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -108,6 +109,14 @@ public class EventNotesTable extends SimpleUserSchema.SimpleTable<SNDUserSchema>
             return result;
         }
 
+        @Override
+        public void configureDataIteratorContext(DataIteratorContext context)
+        {
+            if (context.getInsertOption() == QueryUpdateService.InsertOption.MERGE)
+            {
+                context.addAlternateKeys(Collections.singleton("EventId"));
+            }
+        }
     }
 
     @Override

--- a/src/org/labkey/snd/query/EventsTable.java
+++ b/src/org/labkey/snd/query/EventsTable.java
@@ -53,7 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class EventsTable extends SimpleTable<SNDUserSchema>
+public class  EventsTable extends SimpleTable<SNDUserSchema>
 {
     /**
      * Create the simple table.

--- a/src/org/labkey/snd/query/EventsTable.java
+++ b/src/org/labkey/snd/query/EventsTable.java
@@ -53,7 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class  EventsTable extends SimpleTable<SNDUserSchema>
+public class EventsTable extends SimpleTable<SNDUserSchema>
 {
     /**
      * Create the simple table.


### PR DESCRIPTION
+ Added commits from Marty's feature branch `24.7_fb_di_alt_key`
+ Updated SND Sequencer default values
+ Added isFullReload flag to populateNarrativeCache method and functionality in getBulkSuperPkgs. This prevents the process from getting the entire SuperPackage table from the database when the update is only for a small set of eventIds, and speeds up the ETLs by a lot for iterative updates/merges
+ Generate narratives in the EventNotes ETL so that standalone eventNotes receive narratives in EventCache