### PR TITLE
EventData ETL fix

### DIFF
--- a/src/org/labkey/snd/query/EventDataTable.java
+++ b/src/org/labkey/snd/query/EventDataTable.java
@@ -77,6 +77,7 @@ public class EventDataTable extends AbstractSNDTableInfo
                 return new SQLFragment(tableAliasName).append(".").append("ObjectId");
             }
         };
+        objectid.setNullable(true);
         objectid.setHidden(true);
         objectid.setFk(new BaseColumnInfo.SchemaForeignKey(objectid, "exp", "Object", "ObjectId", false));
         // SimpleTableSchema.SimpleTable.wrapColumn() is weird. It calls addColumn() which is not the usual pattern.

--- a/src/org/labkey/snd/query/EventDataTable.java
+++ b/src/org/labkey/snd/query/EventDataTable.java
@@ -77,7 +77,7 @@ public class EventDataTable extends AbstractSNDTableInfo
                 return new SQLFragment(tableAliasName).append(".").append("ObjectId");
             }
         };
-        objectid.setNullable(true);
+        objectid.setUserEditable(false);
         objectid.setHidden(true);
         objectid.setFk(new BaseColumnInfo.SchemaForeignKey(objectid, "exp", "Object", "ObjectId", false));
         // SimpleTableSchema.SimpleTable.wrapColumn() is weird. It calls addColumn() which is not the usual pattern.


### PR DESCRIPTION
#### Rationale
The new objectid calculated column is throwing an error when importing data. Set that column to nullable.

#### Changes
* Set objId column to nullable
