### PR TITLE
Prevent Narrative Cache update from exceeding the parameter limit in SQL Server

### DIFF
--- a/src/org/labkey/snd/SNDManager.java
+++ b/src/org/labkey/snd/SNDManager.java
@@ -151,7 +151,7 @@ public class SNDManager
         return new SNDUserSchema(SNDSchema.NAME, null, u, c, SNDSchema.getInstance().getSchema(), RoleManager.getRole(FolderAdminRole.class));
     }
 
-    public static int MAX_MERGE_ROWS = 100000;
+    public static int MAX_MERGE_ROWS = 2000;
 
     public static Logger getLogger(Map<Enum, Object> configParameters, Class<?> clazz)
     {


### PR DESCRIPTION
#### Rationale

The maximum number of parameters allowed by SQL Server is 2,100. When more than 2100 animal events are inserted (via the ETL process), the update fails with this error message:  

Caused by: org.springframework.jdbc.UncategorizedSQLException: ExecutingSelector; uncategorized SQLException; SQL state [S0001]; error code [8003]; The incoming request has too many parameters. The server supports a maximum of 2100 parameters. Reduce the number of parameters and resend the request.


#### Changes
This commit reduces the cutoff for the narrative cache to be truncated and reloaded from 10,000 to 2,000, which is less than the maximum of 2,100 parameters.
