### PR TITLE
Optimize SND data import

### DIFF
--- a/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/src/org/labkey/snd/query/AttributeDataTable.java
@@ -361,11 +361,19 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
             Logger log = SNDManager.getLogger(configParameters, AttributeDataTable.class);
 
             List<Map<String, Object>> data = getMutableData(rows, getDataIteratorContext(errors, InsertOption.MERGE, configParameters));
+
             // Large merge triggers importRows path
-            if (data.size() > SNDManager.MAX_MERGE_ROWS)
+            Set<Object> distinctEventIds = new HashSet<>();
+            for (Map<String, Object> map : data) {
+                distinctEventIds.add(map.get("eventId"));
+            }
+
+            int max_merge_rows = SNDManager.MAX_MERGE_ROWS * 10; //ensure this code path is only triggered by the initial data load
+
+            if (distinctEventIds.size() >= max_merge_rows)
             {
                 data.clear();
-                log.info("More than " + SNDManager.MAX_MERGE_ROWS + " rows. using importRows method.");
+                log.info("More than " + max_merge_rows + " rows. using importRows method.");
                 return importRows(user, container, rows, errors, configParameters, extraScriptContext);
             }
             log.info("Merging rows.");

--- a/src/org/labkey/snd/query/EventDataTable.java
+++ b/src/org/labkey/snd/query/EventDataTable.java
@@ -141,10 +141,18 @@ public class EventDataTable extends AbstractSNDTableInfo
             {
                 return 0;
             }
+
             // Large merge triggers importRows path
-            if (data.size() >= SNDManager.MAX_MERGE_ROWS)
+            Set<Object> distinctEventIds = new HashSet<>();
+            for (Map<String, Object> map : data) {
+                distinctEventIds.add(map.get("eventId"));
+            }
+
+            int max_merge_rows = SNDManager.MAX_MERGE_ROWS * 10; //ensure this code path is only triggered by the initial data load
+
+            if (distinctEventIds.size() >= max_merge_rows)
             {
-                log.info("More than " + SNDManager.MAX_MERGE_ROWS + " rows. using importRows method.");
+                log.info("More than " + max_merge_rows + " rows. using importRows method.");
                 return importRows(user, container, rows, errors, configParameters, extraScriptContext);
             }
 


### PR DESCRIPTION
#### Rationale
The importRows code path is failing with duplicate EventId errors. This code path was introduced to speed up the code when the SND data is initially loaded on the server. Unfortunately, a recent change to reduce the MAX_MERGE_ROWS has caused this code path to be taken in other situations.

We need to ensure the importRows code path is only triggered by the initial data load.

#### Changes
Updated mergeRows in EventDataTable and AttributeDataTable. 
1. Want to ensure the importRows code path is only triggered by the initial data load
2. Changed criteria to look at the number of events instead of the number of eventData or AttributeData rows
